### PR TITLE
Switch http_archive demo to use tags

### DIFF
--- a/http-archive-demo/WORKSPACE
+++ b/http-archive-demo/WORKSPACE
@@ -6,15 +6,17 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-LLVM_BAZEL_COMMIT = "af2ad7e699a83d7da327b740c009cedc10e8bfc2"
+LLVM_COMMIT = "c558c22cab9a555d2e521102b775759381e9727f"
 
-LLVM_BAZEL_SHA256 = "6756f87d0ecc2d172af4c3654072c1aa779d09c33571c830d0b191ae41f72122"
+LLVM_BAZEL_TAG = "llvm-project-%s" % (LLVM_COMMIT,)
+
+LLVM_BAZEL_SHA256 = "df2cf04eaefa60b2a94d9e4b2faafeb47465a04051eb71bec2f2daf7536c190b"
 
 http_archive(
     name = "llvm-bazel",
     sha256 = LLVM_BAZEL_SHA256,
-    strip_prefix = "llvm-bazel-{commit}/llvm-bazel".format(commit = LLVM_BAZEL_COMMIT),
-    url = "https://github.com/google/llvm-bazel/archive/{commit}.tar.gz".format(commit = LLVM_BAZEL_COMMIT),
+    strip_prefix = "llvm-bazel-{tag}/llvm-bazel".format(tag = LLVM_BAZEL_TAG),
+    url = "https://github.com/google/llvm-bazel/archive/{tag}.tar.gz".format(tag = LLVM_BAZEL_TAG),
 )
 
 http_archive(
@@ -27,8 +29,6 @@ http_archive(
         "https://zlib.net/zlib-1.2.11.tar.gz",
     ],
 )
-
-LLVM_COMMIT = "c558c22cab9a555d2e521102b775759381e9727f"
 
 LLVM_SHA256 = "b3651e78f4f3b372273c71cb58e0d0767b61e7d9c93b79fd399065c1148089f5"
 


### PR DESCRIPTION
We can use git tags to avoid having to look up commits corresponding to
a given LLVM revision. The tag format is `llvm-project-${LLVM_COMMIT}`.
I originally tried `llvm/llvm-project@${LLVM_COMMIT}` to make something
that is both autolinked by GitHub and unambiguous in the commit it
references but having URL-encoded characters seemed not worth it.
