### PR TITLE
Add submodule-demo directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,6 @@
 # macOS files
 .DS_Store
 
-# CMake artifacts
-build/
-build-*/
-
 # Bazel artifacts
 /bazel-*
 
@@ -31,3 +27,7 @@ build-*/
 compile_commands.json
 .cache/clangd
 .clangd/
+
+# Submodule demo needs to stay in its own branch to avoid infinite submodule
+# recursion.
+submodule-demo/


### PR DESCRIPTION
This has to be in a separate branch because it includes a submodule of
this repo and we don't want infinite submodule recursion. Ignoring the
directory makes it less of a pain to switch branches back and forth.