### PR TITLE
Move the linking of `libdl.so` from the system to the `Support` library.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -645,6 +645,7 @@ cc_library(
     includes = ["include"],
     linkopts = [
         "-pthread",
+        "-ldl",
     ],
     textual_hdrs = glob([
         "include/llvm/Support/*.def",
@@ -677,7 +678,6 @@ cc_library(
     ]),
     hdrs = glob(["include/llvm/Option/*.h"]),
     copts = llvm_copts,
-    linkopts = ["-ldl"],
     deps = [
         ":Support",
         ":config",


### PR DESCRIPTION
This is actually where the usage of the library starts when we have the
relevant headers enabled.

This patch fixes the build of some users of the `Support` library.