### PR TITLE
Fix auto-integrate action

### DIFF
--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -20,14 +20,6 @@ jobs:
       MERGING_BRANCH: "main"
       INTEGRATION_BRANCH: "auto-integrate"
     steps:
-      - name: Installing dependencies
-        env:
-          BUILDIFIER_VERSION: "3.4.0"
-        run: |
-          python3 -m pip install google-pasta
-          sudo wget "https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION?}/buildifier" -O /usr/bin/buildifier
-          sudo chmod +x /usr/bin/buildifier
-          buildifier --version
       - name: Checking out repository
         uses: actions/checkout@v2
         with:
@@ -47,11 +39,12 @@ jobs:
           ./scripts/clobber_merge.sh "${INTEGRATION_BRANCH?}" "${MERGING_BRANCH?}"
           git submodule update
       - name: Running auto integration
-        run: scripts/auto_integrate.sh
+        run: ./scripts/auto_integrate.sh
       - name: Pushing changes
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.INTEGRATION_BRANCH }}
           tags: true
+          # Override existing tags
           force: true

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -1,0 +1,31 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tags the HEAD commit on main with the corresponding LLVM commit
+
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  auto_integrate:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Tagging head commit
+        run: ./scripts/tag_rev.sh
+      - name: Fetching integration branch
+      - name: Pushing changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+          # Override existing tags
+          force: true

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -20,7 +20,6 @@ jobs:
           submodules: true
       - name: Tagging head commit
         run: ./scripts/tag_rev.sh
-      - name: Fetching integration branch
       - name: Pushing changes
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/scripts/commit_and_tag.sh
+++ b/scripts/commit_and_tag.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Updates for the current LLVM commit and creates a tag.
+#  1. Creates a new commit for the
+#  2. Tags the HEAD commit with the matching LLVM commit.
+
+set -e
+set -o pipefail
+
+LLVM_COMMIT="$(.scripts/get_llvm_commit.sh)"
+SHORT_COMMIT="$(echo ${LLVM_COMMIT?} | cut -c -12)"
+
+git commit -am "Integrate LLVM at llvm/llvm-project@${SHORT_COMMIT?}"
+
+./scripts/tag_rev.sh

--- a/scripts/get_llvm_commit.sh
+++ b/scripts/get_llvm_commit.sh
@@ -4,6 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Walks commits in the LLVM submodule creating new commits for each update.
+# Returns the current submodule revision used for LLVM.
 
-./scripts/traverse_llvm_revs.sh ./scripts/commit_and_tag.sh
+set -e
+set -o pipefail
+
+SUBMODULE_DIR="third_party/llvm-project"
+git submodule status -- ${SUBMODULE_DIR?} | awk '{print $1}' | tr -d '+'

--- a/scripts/tag_rev.sh
+++ b/scripts/tag_rev.sh
@@ -1,19 +1,14 @@
-#!/bin/bash
+a#!/bin/bash
 
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Updates for the current LLVM commit and creates a tag.
-#  1. Generates a new LLVM build file for the current LLVM commit.
-#  2. If there are diffs (including if the current LLVM submocule change was not
-#     committed), creates a new commit.
-#  3. Tags the HEAD commit with the matching LLVM commit.
+# Tags the current HEAD commit with the corresponding LLVM commit from its
+# submodule.
 
 set -e
 set -o pipefail
-
-SUBMODULE_DIR="third_party/llvm-project"
 
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "Working directory not clean. Aborting"
@@ -21,7 +16,6 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
-LLVM_COMMIT="$(git submodule status -- ${SUBMODULE_DIR?} | awk '{print $1}' | tr -d '+')"
-SHORT_COMMIT="$(echo ${LLVM_COMMIT?} | cut -c -12)"
+LLVM_COMMIT="$(.scripts/get_llvm_commit.sh)"
 
 git tag -f "llvm-project-${LLVM_COMMIT?}"

--- a/scripts/tag_rev.sh
+++ b/scripts/tag_rev.sh
@@ -1,4 +1,4 @@
-a#!/bin/bash
+#!/bin/bash
 
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Unconditionally commit submodule updates to the auto-integrate branch.
Having a check for a clean working directory there makes no sense as we
will always have a change to the submodule.

Separately, have an action for just tagging the HEAD commit on `main`.
