### PR TITLE
Remove a disabled GCC warning now that LLVM doesn't hit it.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -24,7 +24,6 @@ llvm_copts = [
     "$(STACK_FRAME_UNLIMITED)",
     "-Wno-unused-parameter",
     "-Wno-comment",
-    "-Wno-class-memaccess",
     "-Wno-maybe-uninitialized",
     "-Wno-misleading-indentation",
     "-Wno-unknown-warning-option",


### PR DESCRIPTION
LLVM's code is fixed in https://reviews.llvm.org/D87755

Once that lands, this warning doesn't need to be disabled here. This is
particularly nice because it stops GCC from complaining when we try to
disable it in C compilations.