### PR TITLE
Enable vulkan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ suitable for more general usage.
 
 # Status
 
-MLIR has Cuda and Vulkan support disabled. LLVM does not yet have configuration
-detection and hardcodes values in the config.
+MLIR has Cuda support and the mlir-vulkan-runner disabled. LLVM does not yet
+have configuration detection and hardcodes values in the config.
 
 # Usage
 

--- a/llvm-bazel/WORKSPACE
+++ b/llvm-bazel/WORKSPACE
@@ -3,9 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load(":configure.bzl", "llvm_configure")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 llvm_configure(
     name = "llvm-project",
     overlay_path = "llvm-project-overlay",
     src_path = "../third_party/llvm-project",
+)
+
+maybe(
+    http_archive,
+    name = "vulkan_headers",
+    strip_prefix = "Vulkan-Headers-9bd3f561bcee3f01d22912de10bb07ce4e23d378",
+    sha256 = "19f491784ef0bc73caff877d11c96a48b946b5a1c805079d9006e3fbaa5c1895",
+    urls = [
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/9bd3f561bcee3f01d22912de10bb07ce4e23d378.tar.gz",
+    ],
+    build_file = "//third_party_build:vulkan_headers.BUILD",
+)
+
+load(":vulkan_sdk.bzl", "vulkan_sdk_setup")
+
+maybe(
+    vulkan_sdk_setup,
+    name = "vulkan_sdk",
 )

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -3129,6 +3129,9 @@ cc_library(
     hdrs = [
         "tools/mlir-vulkan-runner/VulkanRuntime.h",
     ],
+    tags = [
+        "manual",  # Requires an external dependency.
+    ],
     deps = [
         ":IR",
         ":Pass",
@@ -3138,7 +3141,7 @@ cc_library(
         ":Support",
         "//llvm:Support",
         "@vulkan_headers",
-        "@vulkan_sdk//:sdk"
+        "@vulkan_sdk//:sdk",
     ],
 )
 
@@ -3146,6 +3149,9 @@ cc_binary(
     name = "tools/libvulkan-runtime-wrappers.so",
     srcs = ["tools/mlir-vulkan-runner/vulkan-runtime-wrappers.cpp"],
     linkshared = True,
+    tags = [
+        "manual",  # Requires an external dependency (via VulkanRuntime)
+    ],
     deps = [
         ":VulkanRuntime",
         "//llvm:Support",

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -3129,13 +3129,6 @@ cc_library(
     hdrs = [
         "tools/mlir-vulkan-runner/VulkanRuntime.h",
     ],
-    data = [
-        "//third_party/swiftshader/src:libvk_swiftshader.so",
-        "//third_party/swiftshader/src:vulkan_icd_manifest_files",
-    ],
-    tags = [
-        "manual",  # TODO(gcmn) enable this target
-    ],
     deps = [
         ":IR",
         ":Pass",
@@ -3144,8 +3137,8 @@ cc_library(
         ":StandardOps",
         ":Support",
         "//llvm:Support",
-        "//third_party/vulkan_headers",
-        "//third_party/vulkan_loader",
+        "@vulkan_headers",
+        "@vulkan_sdk//:sdk"
     ],
 )
 
@@ -3153,9 +3146,6 @@ cc_binary(
     name = "tools/libvulkan-runtime-wrappers.so",
     srcs = ["tools/mlir-vulkan-runner/vulkan-runtime-wrappers.cpp"],
     linkshared = True,
-    tags = [
-        "manual",  # TODO(gcmn) enable this target
-    ],
     deps = [
         ":VulkanRuntime",
         "//llvm:Support",

--- a/llvm-bazel/third_party_build/vulkan_headers.BUILD
+++ b/llvm-bazel/third_party_build/vulkan_headers.BUILD
@@ -1,0 +1,27 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package(default_visibility = ["//visibility:public"])
+
+# Exports all headers but defining VK_NO_PROTOTYPES to disable the
+# inclusion of C function prototypes. Useful if dynamically loading
+# all symbols via dlopen/etc.
+# Not all headers are hermetic, so they are just included as textual
+# headers to disable additional validation.
+cc_library(
+    name = "vulkan_headers_no_prototypes",
+    defines = ["VK_NO_PROTOTYPES"],
+    includes = ["include"],
+    textual_hdrs = glob(["include/vulkan/*.h"]),
+)
+
+# Exports all headers, including C function prototypes. Useful if statically
+# linking against the Vulkan SDK.
+# Not all headers are hermetic, so they are just included as textual
+# headers to disable additional validation.
+cc_library(
+    name = "vulkan_headers",
+    includes = ["include"],
+    textual_hdrs = glob(["include/vulkan/*.h"]),
+)

--- a/llvm-bazel/vulkan_sdk.bzl
+++ b/llvm-bazel/vulkan_sdk.bzl
@@ -1,0 +1,43 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Repository rule to statically link against the Vulkan SDK.
+
+Requires installing the Vulkan SDK from https://vulkan.lunarg.com/.
+
+If the Vulkan SDK is not installed, this generates an empty rule and you may
+encounter linker errors like `error: undefined reference to 'vkCreateInstance'`.
+"""
+
+def _impl(repository_ctx):
+    if "VULKAN_SDK" in repository_ctx.os.environ:
+        sdk_path = repository_ctx.os.environ["VULKAN_SDK"]
+        repository_ctx.symlink(sdk_path, "vulkan-sdk")
+
+        repository_ctx.file("BUILD", """
+cc_library(
+    name = "sdk",
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": [
+            "vulkan-sdk/Lib/vulkan-1.lib"
+        ],
+        "//conditions:default": [
+            "vulkan-sdk/lib/libvulkan.so.1",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)""")
+    else:
+        # Empty rule. Will fail to link for just targets that use Vulkan.
+        repository_ctx.file("BUILD", """
+cc_library(
+    name = "sdk",
+    srcs = [],
+    visibility = ["//visibility:public"],
+)""")
+
+vulkan_sdk_setup = repository_rule(
+    implementation = _impl,
+    local = True,
+)


### PR DESCRIPTION
Mostly adopts the configuration used in https://github.com/google/iree.

The specific `WORKSPACE` configuration of this (as in all things) is
just one example of how to do this. The key thing is that in order to
use the VulkanRuntime target, users must create appropriate
`@vulkan_headers` and `@vulkan_sdk` repo rules. I'm not aware of an
easy way to make this configurable (not have it rely on a specific
name).

We leave all the targets that rely on external dependencies as "manual"
so that users do not need to configure any additional dependencies to
use llvm-bazel.

TESTED=`bazel build @llvm-project//...`