### PR TITLE
Remove warning configuration from the BUILD file and enhance the

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -8,21 +8,48 @@
 ###############################################################################
 # Prevent invalid caching if input files are modified during a build.
 build --experimental_guard_against_concurrent_changes
-# Default to optimized builds
-# Override via: "-c dbg" or --compilation_mode=dbg
-build --compilation_mode=opt
 
 ###############################################################################
 # Options for "generic_clang" builds: these options should generally apply to
-# either clang or gcc and are curated based on need.
+# builds using a Clang-based compiler, and default to the `clang` executable on
+# the `PATH`. While these are provided for convenience and may serve as a
+# reference, it would be preferable for users to configure an explicit C++
+# toolchain instead of relying on `.bazelrc` files.
 ###############################################################################
+
+# Set the default compiler to the `clang` binary on the `PATH`.
+build:generic_clang --repo_env=CC=clang
 
 # C++14 standard version is required.
 build:generic_clang --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 
-# Default to adding back asserts in optimized builds.
-# This is a good compromise between runtime and debugability.
-build:generic_clang --copt=-UNDEBUG
+# Use `-Wall` and `-Werror` for Clang.
+build:generic_clang --copt=-Wall --copt=-Werror --host_copt=-Wall --host_copt=-Werror
+
+###############################################################################
+# Options for "generic_gcc" builds: these options should generally apply to
+# builds using a GCC-based compiler, and default to the `gcc` executable on
+# the `PATH`. While these are provided for convenience and may serve as a
+# reference, it would be preferable for users to configure an explicit C++
+# toolchain instead of relying on `.bazelrc` files.
+###############################################################################
+
+# Set the default compiler to the `gcc` binary on the `PATH`.
+build:generic_gcc --repo_env=CC=gcc
+
+# C++14 standard version is required.
+build:generic_gcc --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
+
+# Disable GCC warnings that are noisy and/or false positives on LLVM code.
+# These need to be global as some code triggering these is in header files.
+build:generic_gcc --copt=-Wno-unused-parameter --host_copt=-Wno-unused-parameter
+build:generic_gcc --copt=-Wno-comment --host_copt=-Wno-comment
+build:generic_gcc --cxxopt=-Wno-class-memaccess --host_cxxopt=-Wno-class-memaccess
+build:generic_gcc --copt=-Wno-maybe-uninitialized --host_copt=-Wno-maybe-uninitialized
+build:generic_gcc --copt=-Wno-misleading-indentation --host_copt=-Wno-misleading-indentation
+
+# Use `-Werror` for GCC to make sure warnings don't slip past.
+build:generic_gcc --copt=-Werror --host_copt=-Werror
 
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -14,20 +14,13 @@ exports_files(["LICENSE.TXT"])
 
 llvm_host_triple = "x86_64-unknown-linux_gnu"
 
-# FIXME: Would be nice to have a select here on the compiler so that we can use
-# a more minimal list for Clang than we need for GCC. Currently this merges the
-# two lists. However, that results in warning flags that aren't understood by
-# the compiler. For GCC, this will only result in extra warning output when
-# a warning or error occurs for some other reason. For Clang, we disable
-# warning on unknown warning options.
+# It may be tempting to add compiler flags here, but that should be avoided.
+# The necessary warnings and other compile flags should be provided by the
+# toolchain or the `.bazelrc` file. This is just a workaround until we have a
+# widely available feature to enable unlimited stack frame instead of using
+# this `Make` variable.
 llvm_copts = [
     "$(STACK_FRAME_UNLIMITED)",
-    "-Wno-unused-parameter",
-    "-Wno-comment",
-    "-Wno-class-memaccess",
-    "-Wno-maybe-uninitialized",
-    "-Wno-misleading-indentation",
-    "-Wno-unknown-warning-option",
 ]
 
 llvm_targets = [


### PR DESCRIPTION
`.bazelrc` to allow more easy build and test with both Clang and GCC.

I've also added some documentation to avoid simple mistakes, and
enhanced the way `NDEBUG` is defined to be explicit using the `defines`
attribute. While all the C++ toolchains I'm aware of in Bazel already
define this macro in exactly this way, it seems useful to make the build
self documenting by doing it explicitly here. This doesn't preclude
using `--copt=-UNDEBUG` to override it on the command line where needed.

The cleanups to the `.bazelrc` are somewhat opinionated on my part. ;]
It seems really good to make it easy to test different build
configurations here and so getting something a bit more vanilla (rather
than forcing `-c opt` by default seems good. If we want optimizations
enabled by default, a better way to do that is a custom toolchain that
sets up fastbuild with the desired flags, but for this project it
doesn't seem worth it.