### PR TITLE
Introduce a configurable dependency on zlib.

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -10,6 +10,14 @@
 build --experimental_guard_against_concurrent_changes
 
 ###############################################################################
+# Options to select different strategies for linking zlib. The default leaves
+# it disabled.
+###############################################################################
+
+build:zlib_external --repo_env=BAZEL_LLVM_ZLIB_STRATEGY=external
+build:zlib_system --repo_env=BAZEL_LLVM_ZLIB_STRATEGY=system
+
+###############################################################################
 # Options for "generic_clang" builds: these options should generally apply to
 # builds using a Clang-based compiler, and default to the `clang` executable on
 # the `PATH`. While these are provided for convenience and may serve as a

--- a/llvm-bazel/WORKSPACE
+++ b/llvm-bazel/WORKSPACE
@@ -14,6 +14,26 @@ llvm_configure(
 
 maybe(
     http_archive,
+    name = "zlib",
+    build_file = "//third_party_build:zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
+        "https://zlib.net/zlib-1.2.11.tar.gz",
+    ],
+)
+
+load(":zlib.bzl", "llvm_zlib_from_env")
+
+maybe(
+    llvm_zlib_from_env,
+    name = "llvm_zlib",
+    external_zlib = "@zlib",
+)
+
+maybe(
+    http_archive,
     name = "vulkan_headers",
     strip_prefix = "Vulkan-Headers-9bd3f561bcee3f01d22912de10bb07ce4e23d378",
     sha256 = "19f491784ef0bc73caff877d11c96a48b946b5a1c805079d9006e3fbaa5c1895",

--- a/llvm-bazel/deps_impl/BUILD
+++ b/llvm-bazel/deps_impl/BUILD
@@ -1,0 +1,5 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Required to reference files in this package

--- a/llvm-bazel/deps_impl/zlib_disable.BUILD
+++ b/llvm-bazel/deps_impl/zlib_disable.BUILD
@@ -1,0 +1,10 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Empty stub library. This doesn't include zlib and doesn't set the LLVM
+# `#define`s to enable it.
+cc_library(
+    name = "zlib",
+    visibility = ["//visibility:public"],
+)

--- a/llvm-bazel/deps_impl/zlib_external.BUILD
+++ b/llvm-bazel/deps_impl/zlib_external.BUILD
@@ -1,0 +1,11 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Wrapper around an external zlib library to add the relevant LLVM `#define`s.
+cc_library(
+    name = "zlib",
+    defines = ["LLVM_ENABLE_ZLIB=1"],
+    visibility = ["//visibility:public"],
+    deps = ["@external_zlib_repo//:zlib_rule"],
+)

--- a/llvm-bazel/deps_impl/zlib_system.BUILD
+++ b/llvm-bazel/deps_impl/zlib_system.BUILD
@@ -1,0 +1,13 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Wrapper library for the system's zlib. Using this only works if the toolchain
+# already has the relevant header search and library search paths configured.
+# It also sets the relevant LLVM `#define`s to enable zlib.
+cc_library(
+    name = "zlib",
+    defines = ["LLVM_ENABLE_ZLIB=1"],
+    linkopts = ["-lz"],
+    visibility = ["//visibility:public"],
+)

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -649,6 +649,10 @@ cc_library(
     deps = [
         ":Demangle",
         ":config",
+        # We unconditionally depend on the custom LLVM zlib wrapper. This will
+        # be an empty library unless zlib is enabled, in which case it will
+        # both provide the necessary dependencies and configuration defines.
+        "@llvm_zlib//:zlib",
     ],
 )
 

--- a/llvm-bazel/third_party_build/zlib.BUILD
+++ b/llvm-bazel/third_party_build/zlib.BUILD
@@ -1,0 +1,46 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package(
+    default_visibility = ["//visibility:public"],
+    # BSD/MIT-like license (for zlib)
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "crc32.h",
+        "deflate.c",
+        "deflate.h",
+        "gzclose.c",
+        "gzguts.h",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.c",
+        "inflate.h",
+        "inftrees.c",
+        "inftrees.h",
+        "trees.c",
+        "trees.h",
+        "uncompr.c",
+        "zconf.h",
+        "zutil.c",
+        "zutil.h",
+    ],
+    hdrs = ["zlib.h"],
+    copts = [
+        "-Wno-shift-negative-value",
+        "-DZ_HAVE_UNISTD_H",
+    ],
+    includes = ["."],
+)

--- a/llvm-bazel/zlib.bzl
+++ b/llvm-bazel/zlib.bzl
@@ -1,0 +1,112 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Repository rules to configure the zlib used by LLVM.
+
+Most users should pick one of the explicit rules to configure their use of zlib
+with LLVM:
+- `llvm_zlib_external` will link against an external Bazel zlib repository.
+- `llvm_zlib_system` will link against the system zlib (non-hermetically).
+- 'llvm_zlib_disable` will disable zlib completely.
+
+If you would like to make your build configurable, you can use
+`llvm_zlib_from_env`. By default, this will disable zlib, but will inspect
+the environment variable (most easily set with a `--repo_env` flag to the
+Bazel invocation) `BAZEL_LLVM_ZLIB_STRATEGY`. If it is set to `external`,
+then it will behave the same as `llvm_zlib_external`. If it is set to
+`system` then it will behave the same as `llvm_zlib_system`. Any other
+setting will disable zlib the same as not setting it at all.
+"""
+
+def _llvm_zlib_external_impl(repository_ctx):
+    repository_ctx.template(
+        "BUILD",
+        repository_ctx.attr._external_build_template,
+        substitutions = {
+            "@external_zlib_repo//:zlib_rule": str(repository_ctx.attr.external_zlib),
+        },
+        executable = False,
+    )
+
+llvm_zlib_external = repository_rule(
+    implementation = _llvm_zlib_external_impl,
+    attrs = {
+        "_external_build_template": attr.label(
+            default = Label("//deps_impl:zlib_external.BUILD"),
+            allow_single_file = True,
+        ),
+        "external_zlib": attr.label(
+            doc = "The dependency that should be used for the external zlib library.",
+            mandatory = True,
+        ),
+    },
+)
+
+def _llvm_zlib_system_impl(repository_ctx):
+    repository_ctx.template(
+        "BUILD",
+        repository_ctx.attr._system_build_template,
+        executable = False,
+    )
+
+# While it may seem like this needs to be local, it doesn't actually inspect
+# any local state, it just configures to build against that local state.
+llvm_zlib_system = repository_rule(
+    implementation = _llvm_zlib_system_impl,
+    attrs = {
+        "_system_build_template": attr.label(
+            default = Label("//deps_impl:zlib_system.BUILD"),
+            allow_single_file = True,
+        ),
+    },
+)
+
+def _llvm_zlib_disable_impl(repository_ctx):
+    repository_ctx.template(
+        "BUILD",
+        repository_ctx.attr._disable_build_template,
+        executable = False,
+    )
+
+llvm_zlib_disable = repository_rule(
+    implementation = _llvm_zlib_disable_impl,
+    attrs = {
+        "_disable_build_template": attr.label(
+            default = Label("//deps_impl:zlib_disable.BUILD"),
+            allow_single_file = True,
+        ),
+    },
+)
+
+def _llvm_zlib_from_env_impl(repository_ctx):
+    zlib_strategy = repository_ctx.os.environ.get("BAZEL_LLVM_ZLIB_STRATEGY")
+    if zlib_strategy == "external":
+        _llvm_zlib_external_impl(repository_ctx)
+    elif zlib_strategy == "system":
+        _llvm_zlib_system_impl(repository_ctx)
+    else:
+        _llvm_zlib_disable_impl(repository_ctx)
+
+llvm_zlib_from_env = repository_rule(
+    implementation = _llvm_zlib_from_env_impl,
+    attrs = {
+        "_disable_build_template": attr.label(
+            default = Label("//deps_impl:zlib_disable.BUILD"),
+            allow_single_file = True,
+        ),
+        "_external_build_template": attr.label(
+            default = Label("//deps_impl:zlib_external.BUILD"),
+            allow_single_file = True,
+        ),
+        "_system_build_template": attr.label(
+            default = Label("//deps_impl:zlib_system.BUILD"),
+            allow_single_file = True,
+        ),
+        "external_zlib": attr.label(
+            doc = "The dependency that should be used for the external zlib library.",
+            mandatory = True,
+        ),
+    },
+    environ = ["BAZEL_LLVM_ZLIB_STRATEGY"],
+)


### PR DESCRIPTION
This allows users to either explicitly choose how they depend on zlib or
to use an environment variable to select between dependencies. It
includes the mechanical components needed to support external
repositories in a hermetic/Bazel style, system library dependencies, or
disabling zlib entirely.

The local workspace is set up to use the environment variable based
configuration, and some convenient `--config` wrappers are added to
enable us to test things easily.