### PR TITLE
Drop usage of marketplace push action

### DIFF
--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -41,10 +41,5 @@ jobs:
       - name: Running auto integration
         run: ./scripts/auto_integrate.sh
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.INTEGRATION_BRANCH }}
-          tags: true
-          # Override existing tags
-          force: true
+        run: |
+          git push origin "${INTEGRATION_BRANCH?}" --force --tags


### PR DESCRIPTION
This is failing for some mysterious reason at the moment. Basically all
it does is configure auth and call push, but the checkout action should
have already configured auth for us, so not much added value.
