### PR TITLE
Fix bad merge

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -3270,20 +3270,6 @@ cc_binary(
 )
 
 gentbl(
-    name = "llvm-bitcode-strip-opts",
-    tbl_outs = [(
-        "-gen-opt-parser-defs",
-        "tools/llvm-objcopy/BitcodeStripOpts.inc",
-    )],
-    tblgen = ":llvm-tblgen",
-    td_file = "tools/llvm-objcopy/BitcodeStripOpts.td",
-    td_srcs = [
-        "include/llvm/Option/OptParser.td",
-        "tools/llvm-objcopy/CommonOpts.td",
-    ],
-)
-
-gentbl(
     name = "llvm-objcopy-opts",
     tbl_outs = [(
         "-gen-opt-parser-defs",


### PR DESCRIPTION
GitHub screwed up the automatic merge of
https://github.com/google/llvm-bazel/pull/31
resulting in conflicting target names.
