### PR TITLE
Make autointegrate action idempotent

### DIFF
--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -42,6 +42,7 @@ jobs:
           else
             echo "${INTEGRATION_BRANCH?} already branches from ${MERGING_BRANCH?}"
           fi
+          git checkout "${INTEGRATION_BRANCH?}"
           git submodule update
       - name: Running auto integration
         run: ./scripts/auto_integrate.sh

--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -36,10 +36,15 @@ jobs:
           git config --local user.name "Auto Integrate Action"
       - name: Merging in changes
         run: |
-          ./scripts/clobber_merge.sh "${INTEGRATION_BRANCH?}" "${MERGING_BRANCH?}"
+          if ! git merge-base --is-ancestor "${MERGING_BRANCH?}" "${INTEGRATION_BRANCH?}"; then
+            ./scripts/clobber_merge.sh "${INTEGRATION_BRANCH?}" "${MERGING_BRANCH?}"
+          else
+            echo "${INTEGRATION_BRANCH?} already branches from ${MERGING_BRANCH?}"
+          fi
           git submodule update
       - name: Running auto integration
         run: ./scripts/auto_integrate.sh
       - name: Pushing changes
         run: |
-          git push origin "${INTEGRATION_BRANCH?}" --force --tags
+          git push origin "${INTEGRATION_BRANCH?}"
+          git push origin --force --tags

--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -33,7 +33,7 @@ jobs:
           git fetch --no-tags --prune origin "${INTEGRATION_BRANCH?}:${INTEGRATION_BRANCH?}"
       - name: Setting git config
         run: |
-          git config --local user.email "llvm-bazel-github-actions-bot@google.com"
+          git config --local user.email "llvm-bazel-github-bot@google.com"
           git config --local user.name "Auto Integrate Action"
       - name: Merging in changes
         run: |

--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -27,6 +27,7 @@ jobs:
           fetch-depth: 0
           submodules: true
           ref: ${{ env.MERGING_BRANCH }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
       - name: Fetching integration branch
         run: |
           git fetch --no-tags --prune origin "${INTEGRATION_BRANCH?}:${INTEGRATION_BRANCH?}"

--- a/scripts/auto_integrate.sh
+++ b/scripts/auto_integrate.sh
@@ -6,4 +6,6 @@
 
 # Walks commits in the LLVM submodule creating new commits for each update.
 
+set -x
+
 ./scripts/traverse_llvm_revs.sh ./scripts/commit_and_tag.sh

--- a/scripts/auto_integrate.sh
+++ b/scripts/auto_integrate.sh
@@ -6,6 +6,4 @@
 
 # Walks commits in the LLVM submodule creating new commits for each update.
 
-set -x
-
 ./scripts/traverse_llvm_revs.sh ./scripts/commit_and_tag.sh

--- a/scripts/traverse_llvm_revs.sh
+++ b/scripts/traverse_llvm_revs.sh
@@ -11,13 +11,13 @@
 
 set -e
 set -o pipefail
-set -x
 
 BRANCH="${BRANCH:-master}"
 SUBMODULE_DIR="third_party/llvm-project"
 
 pushd "${SUBMODULE_DIR?}"
 START="$(git rev-parse HEAD)"
+# For help debugging https://github.com/actions/checkout/issues/363
 git remote -v
 git checkout "${BRANCH?}"
 git pull --ff-only origin "${BRANCH?}"

--- a/scripts/traverse_llvm_revs.sh
+++ b/scripts/traverse_llvm_revs.sh
@@ -11,12 +11,14 @@
 
 set -e
 set -o pipefail
+set -x
 
 BRANCH="${BRANCH:-master}"
 SUBMODULE_DIR="third_party/llvm-project"
 
 pushd "${SUBMODULE_DIR?}"
 START="$(git rev-parse HEAD)"
+git remote -v
 git checkout "${BRANCH?}"
 git pull --ff-only origin "${BRANCH?}"
 git checkout "${START?}"


### PR DESCRIPTION
This allows us to trigger it on other events (e.g. a cron) to update
for new LLVM commits without constantly clobbering the auto-integrate
branch.

Also switches to a personal access token (for a bot) so that there
aren't issues pushing workflow files (which I ran into while testing)
and so that the action can trigger webhooks for other automation (e.g.
builds).

I'm experiencing some intermittent failures that look like
https://github.com/actions/checkout/issues/363, but those were
happening before this change as well.

Tested:
Ran on my fork:
https://github.com/GMNGeoffrey/llvm-bazel/runs/1201208655
Second run:
https://github.com/GMNGeoffrey/llvm-bazel/runs/1201226878