### PR TITLE
Run auto-integrate every 15 minutes

### DIFF
--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -12,9 +12,14 @@ name: Auto Integrate
 on:
   push:
     branches: [main]
+  schedule:
+    # Every 15 minutes
+    - cron: "*/15 * * * *"
 
 jobs:
   auto_integrate:
+    # Don't run on forks
+    if: github.repository == 'google/llvm-bazel'
     runs-on: ubuntu-18.04
     env:
       MERGING_BRANCH: "main"

--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -21,10 +21,22 @@ jobs:
     # Don't run on forks
     if: github.repository == 'google/llvm-bazel'
     runs-on: ubuntu-18.04
+    # Mostly so that busy-waiting through turnstyle is not indefinite.
+    timeout-minutes: 15
     env:
       MERGING_BRANCH: "main"
       INTEGRATION_BRANCH: "auto-integrate"
     steps:
+      # Busy-wait for previous workflow invocations to finish. GitHub actions do
+      # not provide a good way to limit the number of instances of a single
+      # workflow. We don't want multiple of these running at once since they
+      # push and will invalidate eachother.
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checking out repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This will pick up new LLVM commits as they come in.

Includes usage of https://github.com/softprops/turnstyle to avoid
concurrent workflow runs. Unfortunately that relies on busy-waiting,
but GitHub actions don't appear to offer any better alternatives :-/

Tested:
Pushed to my fork.
https://github.com/GMNGeoffrey/llvm-bazel/runs/1203584139 waited for
https://github.com/GMNGeoffrey/llvm-bazel/runs/1203580562 to complete.
https://github.com/GMNGeoffrey/llvm-bazel/runs/1203598644 triggered on
a schedule.