### PR TITLE
Configure RBE

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -62,6 +62,60 @@ build:generic_gcc --copt=-Wno-misleading-indentation --host_copt=-Wno-misleading
 # Use `-Werror` for GCC to make sure warnings don't slip past.
 build:generic_gcc --copt=-Werror --host_copt=-Werror
 
+###############################################################################
+# Configuration for building remotely using Remote Build Execution (RBE)
+# https://cloud.google.com/remote-build-execution/
+# Based on https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-1.0.0.bazelrc
+###############################################################################
+
+build:rbe --remote_instance_name=projects/llvm-bazel/instances/default_instance
+
+# Depending on how many machines are in the remote execution instance, setting
+# this higher can make builds faster by allowing more jobs to run in parallel.
+# Setting it too high can result in jobs that timeout, however, while waiting
+# for a remote machine to execute them.
+build:rbe --jobs=50
+
+# Set several flags related to specifying the platform, toolchain and java
+# properties.
+# These flags should only be used as is for the rbe-ubuntu16-04 container
+# and need to be adapted to work with other toolchain containers.
+build:rbe --host_javabase=@rbe_default//java:jdk
+build:rbe --javabase=@rbe_default//java:jdk
+build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --crosstool_top=@rbe_default//cc:toolchain
+build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# Platform flags:
+# The toolchain container used for execution is defined in the target indicated
+# by "extra_execution_platforms", "host_platform" and "platforms".
+# More about platforms: https://docs.bazel.build/versions/master/platforms.html
+build:rbe --extra_toolchains=@rbe_default//config:cc-toolchain
+build:rbe --extra_execution_platforms=@rbe_default//config:platform
+build:rbe --host_platform=@rbe_default//config:platform
+build:rbe --platforms=@rbe_default//config:platform
+
+build:rbe --define=EXECUTOR=remote
+
+# Enable remote execution so actions are performed on the remote systems.
+build:rbe --remote_executor=grpcs://remotebuildexecution.googleapis.com
+
+# Enforce stricter environment rules, which eliminates some non-hermetic
+# behavior and therefore improves both the remote cache hit rate and the
+# correctness and repeatability of the build.
+build:rbe --incompatible_strict_action_env=true
+
+# Set a higher timeout value, just in case.
+build:rbe --remote_timeout=3600
+
+# Local disk cache is incompatible with remote execution (for obvious reasons).
+build:rbe --disk_cache=""
+
+# Enable authentication. This will pick up application default credentials by
+# default. You can use --google_credentials=some_file.json to use a service
+# account credential instead.
+build:rbe --google_default_credentials=true
+
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.
 try-import %workspace%/user.bazelrc

--- a/llvm-bazel/WORKSPACE
+++ b/llvm-bazel/WORKSPACE
@@ -42,12 +42,12 @@ maybe(
 maybe(
     http_archive,
     name = "vulkan_headers",
-    strip_prefix = "Vulkan-Headers-9bd3f561bcee3f01d22912de10bb07ce4e23d378",
+    build_file = "//third_party_build:vulkan_headers.BUILD",
     sha256 = "19f491784ef0bc73caff877d11c96a48b946b5a1c805079d9006e3fbaa5c1895",
+    strip_prefix = "Vulkan-Headers-9bd3f561bcee3f01d22912de10bb07ce4e23d378",
     urls = [
         "https://github.com/KhronosGroup/Vulkan-Headers/archive/9bd3f561bcee3f01d22912de10bb07ce4e23d378.tar.gz",
     ],
-    build_file = "//third_party_build:vulkan_headers.BUILD",
 )
 
 load(":vulkan_sdk.bzl", "vulkan_sdk_setup")
@@ -56,3 +56,16 @@ maybe(
     vulkan_sdk_setup,
     name = "vulkan_sdk",
 )
+
+http_archive(
+    name = "bazel_toolchains",
+    sha256 = "2431088b38fd8e2878db17e3c5babb431de9e5c52b6d8b509d3070fa279a5be2",
+    strip_prefix = "bazel-toolchains-3.3.1",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.3.1/bazel-toolchains-3.3.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.3.1/bazel-toolchains-3.3.1.tar.gz",
+    ],
+)
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+rbe_autoconfig(name = "rbe_default")

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2520,6 +2520,9 @@ cc_library(
         # lld uses Microsoft mt.exe instead, which is not cross-platform.
         "-lxml2",
     ],
+    tags = [
+        "manual",  # TODO(gcmn): Fix remote execution and re-enable
+    ],
     deps = [
         ":Support",
         ":config",
@@ -3241,6 +3244,9 @@ cc_binary(
     ]),
     copts = llvm_copts,
     stamp = 0,
+    tags = [
+        "manual" # TODO(gcmn): Fix remote execution and re-enable
+    ],
     deps = [
         ":MtTableGen",
         ":Option",


### PR DESCRIPTION
This allows remotely executing and caching actions.

The primary motivation is to be able to have a cluster of build agents
all sharing a cache.

We have one issue with using the default RBE toolchain: it doesn't have
xml2-dev, so we get link failures for WindowsManifest. For now, I've
marked the target manual. I also played around with the
`no-remote-exec` tag, but there are two issues: It doesn't actually
*work* without an experimental flag
https://github.com/bazelbuild/bazel/issues/7988. Even turning that on,
Bazel tries to look for the clang binary at the path it would be on the
remote on the local machine, which doesn't work so well.

> src/main/tools/linux-sandbox-pid1.cc:426:
"execvp(/usr/local/bin/clang, 0x1f81180)": No such file or directory

To get this working, we can use a custom docker container for our
toolchain that includes the right dependencies. This isn't too hard to
set up. But before I do it, do we actually care about this binary right
now? I can punt if we don't.