### PR TITLE
Exit successfully when up to date with remote

### DIFF
--- a/scripts/traverse_llvm_revs.sh
+++ b/scripts/traverse_llvm_revs.sh
@@ -21,14 +21,19 @@ START="$(git rev-parse HEAD)"
 git remote -v
 git checkout "${BRANCH?}"
 git pull --ff-only origin "${BRANCH?}"
-git checkout "${START?}"
-readarray -t commits < <(git rev-list --reverse --ancestry-path HEAD..${BRANCH?})
+
+if [[ "$(git rev-parse ${BRANCH?})" == "${START?}" ]]; then
+  echo "Current HEAD is already up to date with ${BRANCH?}"
+  popd
+  exit 0
+fi
+
+readarray -t commits < <(git rev-list --reverse --ancestry-path ${START?}..${BRANCH?})
 if [[ ${#commits[@]} == 0 ]]; then
   echo "Failed to find path between current HEAD and ${BRANCH?}"
   popd
   exit 1
 fi
-git status
 popd
 
 for commit in "${commits[@]?}"; do


### PR DESCRIPTION
Now that we're running on a cron, it's actually not unlikely that the
submodule is already up to date (just happened).