### PR TITLE
Tag all commits on push

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -11,20 +11,14 @@ on:
     branches: [main]
 
 jobs:
-  auto_integrate:
+  auto_tag:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
         with:
-          submodules: true
-      - name: Tagging head commit
-        run: ./scripts/tag_rev.sh
+          fetch-depth: 0
+      - name: Tagging new commits
+        run: ./scripts/tag_since.sh "${{ github.event.before }}"
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          tags: true
-          # Override existing tags
-          force: true
+        run: git push origin --tags --force

--- a/scripts/get_llvm_commit.sh
+++ b/scripts/get_llvm_commit.sh
@@ -10,4 +10,4 @@ set -e
 set -o pipefail
 
 SUBMODULE_DIR="third_party/llvm-project"
-git submodule status -- ${SUBMODULE_DIR?} | awk '{print $1}' | tr -d '+'
+git submodule status -- ${SUBMODULE_DIR?} | awk '{print $1}' | tr -d '+-'

--- a/scripts/tag_since.sh
+++ b/scripts/tag_since.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tags each commit between the specified commit and the current HEAD (exclusive
+# and inclusive, respectively) with the corresponding LLVM commit from its
+# submodule. Tags commits sequentially starting from the oldest, so if multiple
+# commits correspond to the same LLVM submodule, the newest will end up with the
+# tag.
+
+set -e
+set -o pipefail
+
+START="${1?}"
+
+readarray -t commits < <(git rev-list --reverse --ancestry-path "${START?}..HEAD")
+if [[ ${#commits[@]} == 0 ]]; then
+  echo "Failed to find path between current HEAD and ${START?}"
+  exit 1
+fi
+
+for commit in "${commits[@]?}"; do
+  git checkout "${commit?}"
+  git submodule update
+  ./scripts/tag_rev.sh
+done

--- a/scripts/traverse_llvm_revs.sh
+++ b/scripts/traverse_llvm_revs.sh
@@ -28,7 +28,7 @@ if [[ "$(git rev-parse ${BRANCH?})" == "${START?}" ]]; then
   exit 0
 fi
 
-readarray -t commits < <(git rev-list --reverse --ancestry-path ${START?}..${BRANCH?})
+readarray -t commits < <(git rev-list --reverse --ancestry-path "${START?}..${BRANCH?}")
 if [[ ${#commits[@]} == 0 ]]; then
   echo "Failed to find path between current HEAD and ${BRANCH?}"
   popd


### PR DESCRIPTION
Previously it would only tag the HEAD commit, which means we couldn't
push multiple commits at once.

Tested:
Pushed to my fork
![tag_since](https://user-images.githubusercontent.com/5732088/95272436-1f649700-07f5-11eb-8f4b-f0d123cf65e2.png)
