### PR TITLE
Explicitly tag targets that don't build on Build Kite

### DIFF
--- a/llvm-bazel/configure.bzl
+++ b/llvm-bazel/configure.bzl
@@ -10,4 +10,4 @@ load(":overlay_directories.bzl", "overlay_directories")
 OVERLAY_DIR = "llvm-project-overlay"
 
 def llvm_configure(name, overlay_path = OVERLAY_DIR, **kwargs):
-    overlay_directories(name=name, overlay_path=overlay_path, **kwargs)
+    overlay_directories(name = name, overlay_path = overlay_path, **kwargs)

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2522,7 +2522,9 @@ cc_library(
         "-lxml2",
     ],
     tags = [
-        "manual",  # TODO(gcmn): Fix remote execution and re-enable
+        # TODO(gcmn): Fix remote execution and re-enable
+        "nobuildkite",
+        "manual",
     ],
     deps = [
         ":Support",
@@ -2573,7 +2575,9 @@ cc_library(
     copts = llvm_copts + ["-DHAVE_LIBPFM=1"],
     defines = ["LLVM_EXEGESIS_INITIALIZE_NATIVE_TARGET=InitializeX86ExegesisTarget"],
     tags = [
-        "manual",  # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.
+        # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.
+        "nobuildkite",
+        "manual",
     ],
     deps = [
         ":AllTargetsAsmParsers",
@@ -2965,7 +2969,9 @@ cc_binary(
     copts = llvm_copts + ["-DHAVE_LIBPFM=0"],
     stamp = 0,
     tags = [
-        "manual",  # TODO(chandlerc): Remove when the library builds.
+        # TODO(chandlerc): Enable when the library builds.
+        "nobuildkite",
+        "manual",
     ],
     deps = [
         ":AllTargetsAsmParsers",
@@ -3246,7 +3252,9 @@ cc_binary(
     copts = llvm_copts,
     stamp = 0,
     tags = [
-        "manual" # TODO(gcmn): Fix remote execution and re-enable
+        # TODO(gcmn): Enable when WindowsManifest builds.
+        "nobuildkite",
+        "manual",
     ],
     deps = [
         ":MtTableGen",

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2091,9 +2091,8 @@ cc_library(
         "-lxml2",
     ],
     tags = [
-        # TODO(gcmn): Fix remote execution and re-enable
-        "nobuildkite",
-        "manual",
+        "manual",  # External dependency (libxml)
+        "nobuildkite",  # TODO(gcmn): Fix remote execution and re-enable
     ],
     deps = [
         ":Support",
@@ -2144,9 +2143,8 @@ cc_library(
     copts = llvm_copts + ["-DHAVE_LIBPFM=1"],
     defines = ["LLVM_EXEGESIS_INITIALIZE_NATIVE_TARGET=InitializeX86ExegesisTarget"],
     tags = [
-        # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.
-        "nobuildkite",
-        "manual",
+        "manual",  # External dependency (libpfm4)
+        "nobuildkite",  # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.
     ],
     deps = [
         ":AllTargetsAsmParsers",
@@ -2538,9 +2536,8 @@ cc_binary(
     copts = llvm_copts + ["-DHAVE_LIBPFM=0"],
     stamp = 0,
     tags = [
-        # TODO(chandlerc): Enable when the library builds.
-        "nobuildkite",
-        "manual",
+        "manual",  # TODO(chandlerc): Enable when the library builds.
+        "nobuildkite",  # TODO(chandlerc): Enable when the library builds.
     ],
     deps = [
         ":AllTargetsAsmParsers",
@@ -2821,7 +2818,8 @@ cc_binary(
     copts = llvm_copts,
     stamp = 0,
     tags = [
-        "manual",  # TODO(gcmn): Fix remote execution and re-enable
+        "manual",  # TODO(gcmn): External dependency (through WindowsManifest)
+        "nobuildkite",  # TODO(gcmn): Re-enable when WindowsManifest builds
     ],
     deps = [
         ":MtTableGen",

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -3289,7 +3289,7 @@ cc_binary(
     srcs = ["tools/mlir-vulkan-runner/vulkan-runtime-wrappers.cpp"],
     linkshared = True,
     tags = [
-        "manual",  # Requires an external dependency.
+        "manual",  # External dependency (through VulkanRuntime)
     ],
     deps = [
         ":VulkanRuntime",

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -163,7 +163,8 @@ cc_library(
         "include/mlir-c/Bindings/Python/Interop.h",
     ],
     tags = [
-        "manual",  # TODO(gcmn): Add support for this target
+        "manual",  # External dependency
+        "nobuildkite",  # TODO(gcmn): Add support for this target
     ],
     deps = [
         ":CAPIIR",
@@ -3237,7 +3238,8 @@ cc_library(
     name = "tools/libcuda-runtime-wrappers",
     srcs = ["tools/mlir-cuda-runner/cuda-runtime-wrappers.cpp"],
     tags = [
-        "manual",  # TODO(gcmn): Add support for this target
+        "manual",  # External dependency
+        "nobuildkite",  # TODO(gcmn): Add support for this target
     ],
     deps = [
         ":mlir_c_runner_utils",
@@ -3252,7 +3254,8 @@ cc_binary(
     name = "tools/libcuda-runtime-wrappers.so",
     linkshared = True,
     tags = [
-        "manual",  # TODO(gcmn): Add support for this target
+        "manual",  # External dependency
+        "nobuildkite",  # TODO(gcmn): Add support for this target
     ],
     deps = [":tools/libcuda-runtime-wrappers"],
 )
@@ -3266,7 +3269,7 @@ cc_library(
         "tools/mlir-vulkan-runner/VulkanRuntime.h",
     ],
     tags = [
-        "manual",  # Requires an external dependency.
+        "manual",  # External dependency
     ],
     deps = [
         ":IR",
@@ -3299,7 +3302,8 @@ cc_binary(
     srcs = ["tools/mlir-cuda-runner/mlir-cuda-runner.cpp"],
     data = [":tools/libcuda-runtime-wrappers.so"],
     tags = [
-        "manual",  # TODO(gcmn): Add support for this target
+        "manual",  # External dependency
+        "nobuildkite",  # TODO(gcmn): Add support for this target
     ],
     deps = [
         ":AllPassesAndDialectsNoRegistration",
@@ -3333,7 +3337,8 @@ cc_binary(
         "//mlir/test/mlir-cpu-runner:libmlir_runner_utils.so",
     ],
     tags = [
-        "manual",  # TODO(gcmn): Add support for this target
+        "manual",  # External dependency
+        "nobuildkite",  # TODO(gcmn): Add support for this target
     ],
     deps = [
         ":AllPassesAndDialectsNoRegistration",


### PR DESCRIPTION
Some targets are tagged manual for other reasons and manual really just
means "don't build this in wildcards", which is a human-focused
distinction. For build bots, we can now use `bazel query` (which
ignores "manual") piped to `bazel test` to build and test all targets
in parallel (more important as we get more tests).

Tested:
Locally ran
```shell
bazel query //... + @llvm-project//... \
  | xargs bazel test \
    --config=rbe \
    --test_output=errors \
    --test_tag_filters=-nobuildkite \
    --build_tag_filters=-nobuildkite
```