### PR TITLE
Introduce proper rule for changing the basename of a binary

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -5,6 +5,7 @@
 load(":template_rule.bzl", "template_rule")
 load(":tblgen.bzl", "gentbl")
 load(":config.bzl", "llvm_config_defines")
+load(":binary_alias.bzl", "binary_alias")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -2287,19 +2288,19 @@ cc_binary(
 
 # We need to run llvm-ar with different basenames to make it run with
 # different behavior.
-sh_binary(
+binary_alias(
     name = "llvm-dlltool",
-    srcs = [":llvm-ar"],
+    binary = ":llvm-ar",
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-lib",
-    srcs = [":llvm-ar"],
+    binary = ":llvm-ar",
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-ranlib",
-    srcs = [":llvm-ar"],
+    binary = ":llvm-ar",
 )
 
 cc_binary(
@@ -2929,19 +2930,19 @@ cc_binary(
     ],
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-strip",
-    srcs = [":llvm-objcopy"],
+    binary = ":llvm-objcopy",
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-bitcode-strip",
-    srcs = [":llvm-objcopy"],
+    binary = ":llvm-objcopy",
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-install-name-tool",
-    srcs = [":llvm-objcopy"],
+    binary = ":llvm-objcopy",
 )
 
 cc_binary(
@@ -3077,9 +3078,9 @@ cc_binary(
 )
 
 # Create an 'llvm-readelf' named binary from the 'llvm-readobj' tool.
-sh_binary(
+binary_alias(
     name = "llvm-readelf",
-    srcs = [":llvm-readobj"],
+    binary = ":llvm-readobj",
 )
 
 cc_binary(
@@ -3194,9 +3195,9 @@ cc_binary(
     ],
 )
 
-sh_binary(
+binary_alias(
     name = "llvm-addr2line",
-    srcs = [":llvm-symbolizer"],
+    binary = ":llvm-symbolizer",
 )
 
 cc_binary(

--- a/llvm-bazel/llvm-project-overlay/llvm/binary_alias.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/binary_alias.bzl
@@ -1,0 +1,35 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Creates a copy of a binary giving it a different basename.
+
+binary_alias(
+    name = "my_binary_other_name",
+    binary = ":some_cc_binary",
+)
+"""
+
+def _binary_alias_impl(ctx):
+    ctx.actions.expand_template(
+      template = ctx.file.binary,
+      output = ctx.outputs.executable,
+      substitutions = {},
+      is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = ctx.outputs.executable,
+        runfiles = ctx.attr.binary[DefaultInfo].default_runfiles,
+    )]
+
+binary_alias = rule(
+    _binary_alias_impl,
+    attrs = {
+        "binary": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+)

--- a/llvm-bazel/llvm-project-overlay/llvm/binary_alias.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/binary_alias.bzl
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Creates a copy of a binary giving it a different basename.
+"""Creates a copy of a binary, giving it a different basename.
 
 binary_alias(
     name = "my_binary_other_name",
@@ -11,11 +11,10 @@ binary_alias(
 """
 
 def _binary_alias_impl(ctx):
-    ctx.actions.expand_template(
-      template = ctx.file.binary,
-      output = ctx.outputs.executable,
-      substitutions = {},
-      is_executable = True,
+    ctx.actions.symlink(
+        target_file = ctx.executable.binary,
+        output = ctx.outputs.executable,
+        is_executable = True,
     )
 
     return [DefaultInfo(
@@ -28,7 +27,8 @@ binary_alias = rule(
     attrs = {
         "binary": attr.label(
             mandatory = True,
-            allow_single_file = True,
+            executable = True,
+            cfg = "target",
         ),
     },
     executable = True,


### PR DESCRIPTION
Bazel gets upset on Windows with this little hack, and honestly it's
right:

> in sh_binary rule @llvm-project//llvm:llvm-strip: Source file is a
Windows executable file, target name extension should match source file
extension