### PR TITLE
Configuration for a windows build

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -63,6 +63,48 @@ build:generic_gcc --copt=-Wno-misleading-indentation --host_copt=-Wno-misleading
 build:generic_gcc --copt=-Werror --host_copt=-Werror
 
 ###############################################################################
+# Windows specific flags for building with VC.
+###############################################################################
+
+build:msvc --copt=/WX     # Treat warnings as errors...
+
+# ...but disable the ones that are violated
+build:msvc --copt=/wd4624 # destructor was implicitly defined as deleted
+build:msvc --copt=/wd4244 # possible loss of data
+build:msvc --copt=/wd4005 # macro redefinition
+build:msvc --copt=/wd4141 # inline used more than once
+build:msvc --copt=/wd4267 # initializing: possible loss of data
+build:msvc --copt=/wd4273 # multiple definitions with different dllimport
+build:msvc --copt=/wd4319 # zero-extending after complement
+build:msvc --copt=/wd4804 # comparisons between bool and int
+build:msvc --copt=/wd4805 # comparisons between bool and int
+
+build:msvc --linkopt=/WX # Treat warnings as errors...
+
+# ...but disable the ones that are violated.
+build:msvc --linkopt=/IGNORE:4001 # no object files
+build:msvc --linkopt=/IGNORE:4217 # mismatch import/export declspec
+
+# Enables unix-style runfiles link trees (requires symlink permission).
+# See: https://blogs.msvc.com/msvcdeveloper/2016/12/02/symlinks-msvc-10/
+# Generally: Enable Developer Mode in the Developer Settings page of the
+# system settings.
+build:msvc --experimental_enable_runfiles
+build:msvc --copt=/arch:AVX
+# Host and target are the same in msvc so don't waste time building both.
+build:msvc --distinct_host_configuration=false
+# Avoids incompatible versions of winsock and other badness.
+build:msvc --copt=/DWIN32_LEAN_AND_MEAN --host_copt=/DWIN32_LEAN_AND_MEAN
+# Why are min/max macros? No one knows.
+build:msvc --copt=/DNOMINMAX --host_copt=/DNOMINMAX
+# Yay for security warnings. Boo for non-standard.
+build:msvc --copt=/D_CRT_SECURE_NO_WARNINGS --host_copt=/D_CRT_SECURE_NO_WARNINGS
+# Necessary for M_* math constants.
+build:msvc --copt=/D_USE_MATH_DEFINES --host_copt=/D_USE_MATH_DEFINES
+
+###############################################################################
+
+###############################################################################
 # Configuration for building remotely using Remote Build Execution (RBE)
 # https://cloud.google.com/remote-build-execution/
 # Based on https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-1.0.0.bazelrc

--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -66,30 +66,20 @@ build:generic_gcc --copt=-Werror --host_copt=-Werror
 # Windows specific flags for building with VC.
 ###############################################################################
 
-build:msvc --copt=/WX     # Treat warnings as errors...
+build:msvc --copt=/WX --host_copt=/WX    # Treat warnings as errors...
 # ...but disable the ones that are violated
-build:msvc --copt=/wd4141 # inline used more than once
-build:msvc --copt=/wd4244 # conversion type -> type
-build:msvc --copt=/wd4267 # conversion size_t -> type
-build:msvc --copt=/wd4273 # multiple definitions with different dllimport
-build:msvc --copt=/wd4319 # zero-extending after complement
-build:msvc --copt=/wd4624 # destructor was implicitly defined as deleted
-build:msvc --copt=/wd4804 # comparisons between bool and int
-build:msvc --copt=/wd4805 # comparisons between bool and int
+build:msvc --copt=/wd4141 --host_copt=/wd4141 # inline used more than once
+build:msvc --copt=/wd4244 --host_copt=/wd4244 # conversion type -> type
+build:msvc --copt=/wd4267 --host_copt=/wd4267 # conversion size_t -> type
+build:msvc --copt=/wd4273 --host_copt=/wd4273 # multiple definitions with different dllimport
+build:msvc --copt=/wd4319 --host_copt=/wd4319 # zero-extending after complement
+build:msvc --copt=/wd4624 --host_copt=/wd4624 # destructor was implicitly defined as deleted
+build:msvc --copt=/wd4804 --host_copt=/wd4804 # comparisons between bool and int
+build:msvc --copt=/wd4805 --host_copt=/wd4805 # comparisons between bool and int
 
-build:msvc --linkopt=/WX # Treat warnings as errors...
+build:msvc --linkopt=/WX --host_linkopt=/WX # Treat warnings as errors...
 # ...but disable the ones that are violated.
-build:msvc --linkopt=/IGNORE:4001 # no object files
-
-# Enables unix-style runfiles link trees (requires symlink permission).
-# See: https://blogs.msvc.com/msvcdeveloper/2016/12/02/symlinks-msvc-10/
-# Generally: Enable Developer Mode in the Developer Settings page of the
-# system settings.
-# https://docs.bazel.build/versions/master/windows.html#enable-symlink-support
-build:msvc --enable_runfiles
-
-# Host and target are the same in msvc so don't waste time building both.
-build:msvc --distinct_host_configuration=false
+build:msvc --linkopt=/IGNORE:4001 --host_linkopt=/IGNORE:4001 # no object files
 
 # Yay for security warnings. Boo for non-standard.
 build:msvc --copt=/D_CRT_SECURE_NO_WARNINGS --host_copt=/D_CRT_SECURE_NO_WARNINGS

--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -67,40 +67,32 @@ build:generic_gcc --copt=-Werror --host_copt=-Werror
 ###############################################################################
 
 build:msvc --copt=/WX     # Treat warnings as errors...
-
 # ...but disable the ones that are violated
-build:msvc --copt=/wd4624 # destructor was implicitly defined as deleted
-build:msvc --copt=/wd4244 # possible loss of data
-build:msvc --copt=/wd4005 # macro redefinition
 build:msvc --copt=/wd4141 # inline used more than once
-build:msvc --copt=/wd4267 # initializing: possible loss of data
+build:msvc --copt=/wd4244 # conversion type -> type
+build:msvc --copt=/wd4267 # conversion size_t -> type
 build:msvc --copt=/wd4273 # multiple definitions with different dllimport
 build:msvc --copt=/wd4319 # zero-extending after complement
+build:msvc --copt=/wd4624 # destructor was implicitly defined as deleted
 build:msvc --copt=/wd4804 # comparisons between bool and int
 build:msvc --copt=/wd4805 # comparisons between bool and int
 
 build:msvc --linkopt=/WX # Treat warnings as errors...
-
 # ...but disable the ones that are violated.
 build:msvc --linkopt=/IGNORE:4001 # no object files
-build:msvc --linkopt=/IGNORE:4217 # mismatch import/export declspec
 
 # Enables unix-style runfiles link trees (requires symlink permission).
 # See: https://blogs.msvc.com/msvcdeveloper/2016/12/02/symlinks-msvc-10/
 # Generally: Enable Developer Mode in the Developer Settings page of the
 # system settings.
-build:msvc --experimental_enable_runfiles
-build:msvc --copt=/arch:AVX
+# https://docs.bazel.build/versions/master/windows.html#enable-symlink-support
+build:msvc --enable_runfiles
+
 # Host and target are the same in msvc so don't waste time building both.
 build:msvc --distinct_host_configuration=false
-# Avoids incompatible versions of winsock and other badness.
-build:msvc --copt=/DWIN32_LEAN_AND_MEAN --host_copt=/DWIN32_LEAN_AND_MEAN
-# Why are min/max macros? No one knows.
-build:msvc --copt=/DNOMINMAX --host_copt=/DNOMINMAX
+
 # Yay for security warnings. Boo for non-standard.
 build:msvc --copt=/D_CRT_SECURE_NO_WARNINGS --host_copt=/D_CRT_SECURE_NO_WARNINGS
-# Necessary for M_* math constants.
-build:msvc --copt=/D_USE_MATH_DEFINES --host_copt=/D_USE_MATH_DEFINES
 
 ###############################################################################
 

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -208,10 +208,13 @@ cc_library(
     ],
     copts = llvm_copts,
     includes = ["include"],
-    linkopts = [
-        "-pthread",
-        "-ldl",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-pthread",
+            "-ldl",
+        ],
+    }),
     textual_hdrs = glob([
         "include/llvm/Support/*.def",
     ]),
@@ -2237,15 +2240,18 @@ cc_binary(
     copts = llvm_copts,
     # ll scripts rely on symbols from dependent
     # libraries being resolvable.
-    linkopts = [
-        "-Wl,--undefined=_ZTIi",
-        "-Wl,--export-dynamic-symbol=_ZTIi",
-        "-Wl,--export-dynamic-symbol=__cxa_begin_catch",
-        "-Wl,--export-dynamic-symbol=__cxa_end_catch",
-        "-Wl,--export-dynamic-symbol=__gxx_personality_v0",
-        "-Wl,--export-dynamic-symbol=__cxa_allocate_exception",
-        "-Wl,--export-dynamic-symbol=__cxa_throw",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wl,--undefined=_ZTIi",
+            "-Wl,--export-dynamic-symbol=_ZTIi",
+            "-Wl,--export-dynamic-symbol=__cxa_begin_catch",
+            "-Wl,--export-dynamic-symbol=__cxa_end_catch",
+            "-Wl,--export-dynamic-symbol=__gxx_personality_v0",
+            "-Wl,--export-dynamic-symbol=__cxa_allocate_exception",
+            "-Wl,--export-dynamic-symbol=__cxa_throw",
+        ],
+    }),
     stamp = 0,
     deps = [
         ":AllTargetsAsmParsers",
@@ -2595,15 +2601,18 @@ cc_binary(
     ]),
     copts = llvm_copts,
     # Make symbols from the standard library dynamically resolvable.
-    linkopts = [
-        "-Wl,--undefined=_ZTIi",
-        "-Wl,--export-dynamic-symbol=_ZTIi",
-        "-Wl,--export-dynamic-symbol=__cxa_begin_catch",
-        "-Wl,--export-dynamic-symbol=__cxa_end_catch",
-        "-Wl,--export-dynamic-symbol=__gxx_personality_v0",
-        "-Wl,--export-dynamic-symbol=__cxa_allocate_exception",
-        "-Wl,--export-dynamic-symbol=__cxa_throw",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wl,--undefined=_ZTIi",
+            "-Wl,--export-dynamic-symbol=_ZTIi",
+            "-Wl,--export-dynamic-symbol=__cxa_begin_catch",
+            "-Wl,--export-dynamic-symbol=__cxa_end_catch",
+            "-Wl,--export-dynamic-symbol=__gxx_personality_v0",
+            "-Wl,--export-dynamic-symbol=__cxa_allocate_exception",
+            "-Wl,--export-dynamic-symbol=__cxa_throw",
+        ],
+    }),
     stamp = 0,
     deps = [
         ":AllTargetsAsmParsers",
@@ -3238,7 +3247,10 @@ cc_binary(
         "tools/opt/*.h",
     ]),
     copts = llvm_copts,
-    linkopts = ["-Wl,--export-dynamic"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": ["-Wl,--export-dynamic"],
+    }),
     stamp = 0,
     deps = [
         ":AllTargetsAsmParsers",
@@ -3351,10 +3363,12 @@ cc_library(
     copts = llvm_copts + ["-Iexternal/llvm-project/llvm/utils/unittest/googletest"],
     defines = [
         "GTEST_HAS_RTTI=0",
-        "GTEST_USE_OWN_TR1_TUPLE",
         "__STDC_LIMIT_MACROS",
         "__STDC_CONSTANT_MACROS",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:windows": ["GTEST_USE_OWN_TR1_TUPLE=0"],
+        "//conditions:default": ["GTEST_USE_OWN_TR1_TUPLE=1"],
+    }),
     includes = [
         "include",
         "utils/unittest/googletest/include",
@@ -3486,10 +3500,13 @@ cc_binary(
     # from libstdc++ such as __cxa_begin_catch and _ZTIi. The latter
     # isn't even used in the main binary, so we also need to force it
     # to be included.
-    linkopts = [
-        "-rdynamic",
-        "-u_ZTIi",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-rdynamic",
+            "-u_ZTIi",
+        ],
+    }),
     stamp = 0,
     deps = [
         ":OrcJIT",

--- a/llvm-bazel/llvm-project-overlay/llvm/config.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/config.bzl
@@ -21,6 +21,13 @@ posix_defines = [
     "BACKTRACE_HEADER=<execinfo.h>",
     "LTDL_SHLIB_EXT=\\\".so\\\"",
     "LLVM_ENABLE_THREADS=1",
+    "HAVE_SYSEXITS_H=1",
+    "HAVE_UNISTD_H=1",
+    "HAVE_STRERROR_R=1",
+    "HAVE_LIBPTHREAD=1",
+    "HAVE_PTHREAD_GETNAME_NP=1",
+    "HAVE_PTHREAD_SETNAME_NP=1",
+    "HAVE_PTHREAD_GETSPECIFIC=1",
 ]
 
 win32_defines = [

--- a/llvm-bazel/llvm-project-overlay/llvm/config.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/config.bzl
@@ -37,11 +37,6 @@ win32_defines = [
 
     # LLVM features
     "LTDL_SHLIB_EXT=\\\".dll\\\"",
-
-    # ThreadPoolExecutor global destructor and thread handshaking do not work
-    # on this platform when used as a DLL.
-    # See: https://bugs.llvm.org/show_bug.cgi?id=44211
-    "LLVM_ENABLE_THREADS=0",
 ]
 
 llvm_config_defines = select({

--- a/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+++ b/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
@@ -192,7 +192,7 @@
 #define HAVE_STRERROR 1
 
 /* Define to 1 if you have the `strerror_r' function. */
-#define HAVE_STRERROR_R 1
+/* HAVE_STRERROR_R defined in Bazel */
 
 /* Define to 1 if you have the `sysconf' function. */
 #define HAVE_SYSCONF 1
@@ -234,7 +234,7 @@
 #define HAVE_TERMIOS_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
+/* HAVE_UNISTD_H defined in Bazel */
 
 /* Define to 1 if you have the <valgrind/valgrind.h> header file. */
 /* #undef HAVE_VALGRIND_VALGRIND_H */

--- a/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+++ b/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
@@ -29,7 +29,7 @@
 /* LLVM_DEFAULT_TARGET_TRIPLE defined in Bazel */
 
 /* Define if threads enabled */
-/* LLVM_ENABLE_THREADS defined in Bazel */
+#define LLVM_ENABLE_THREADS 1
 
 /* Has gcc/MSVC atomic intrinsics */
 #define LLVM_HAS_ATOMICS 1

--- a/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+++ b/llvm-bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
@@ -97,6 +97,6 @@
 /* #undef LLVM_HAVE_TF_AOT */
 
 /* Define to 1 if you have the <sysexits.h> header file. */
-#define HAVE_SYSEXITS_H 1
+/* HAVE_SYSEXITS_H defined in Bazel */
 
 #endif

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -92,10 +92,13 @@ cc_library(
         "include/mlir/Pass/*.h",
     ]),
     includes = ["include"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-lpthread",
+            "-ldl",
+        ],
+    }),
     deps = [
         ":IR",
         ":Support",
@@ -3227,7 +3230,10 @@ cc_library(
 cc_binary(
     name = "mlir-cpu-runner",
     srcs = ["tools/mlir-cpu-runner/mlir-cpu-runner.cpp"],
-    linkopts = ["-ldl"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": ["-ldl"],
+    }),
     deps = [
         ":AllPassesAndDialectsNoRegistration",
         ":ExecutionEngineUtils",
@@ -3390,10 +3396,13 @@ cc_binary(
         "tools/mlir-tblgen/*.h",
         "tools/mlir-tblgen/*.cpp",
     ]),
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-lm",
+            "-lpthread",
+        ],
+    }),
     deps = [
         ":MlirTableGenMain",
         ":Support",
@@ -3409,10 +3418,13 @@ cc_binary(
     srcs = glob([
         "tools/mlir-linalg-ods-gen/mlir-linalg-ods-gen.cpp",
     ]),
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-lm",
+            "-lpthread",
+        ],
+    }),
     deps = [
         ":IR",
         ":Support",


### PR DESCRIPTION
This now builds with warnings-as-errors (which requires disabling quite
a few warnings).

I am by no means a Windows expert. I just got my hands on a Windows VM
and fixed things until everything built. Requires
https://github.com/google/llvm-bazel/pull/59,
https://reviews.llvm.org/D89760, and https://reviews.llvm.org/D89758
to build cleanly.

There are a lot of places where we set linkopts iff not windows. Might
want to factor that into a macro, but I decided to wait till we had more
configurations to see if that would remain the differentiator.
