### PR TITLE
Clean-up and remove hard-coded flag from `tblgen` Bazel rule.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
@@ -40,10 +40,10 @@ def gentbl(name, tblgen, td_file, td_srcs, tbl_outs, library = True, **kwargs):
             outs = [out],
             tools = [tblgen],
             message = "Generating code from table: %s" % td_file,
-            cmd = (("$(location %s) " + "-I external/llvm-project/llvm/include " +
+            cmd = (("$(location %s) -I external/llvm-project/llvm/include " +
                     "-I external/llvm-project/clang/include " +
-                    "-I $$(dirname $(location %s)) " + ("%s $(location %s) --long-string-literals=0 " +
-                                                        "-o $@")) % (
+                    "-I $$(dirname $(location %s)) " +
+                    "%s $(location %s) -o $@") % (
                 tblgen,
                 td_file,
                 opts,


### PR DESCRIPTION
The hard coded flag disables the use of long string literals. This isn't
supported for all tablegen tools, and isn't desirable in any of them. It
is a workaround for compilers that can't handle the long string
literals. For compilers that can handle these literals, using them is
a (significant) compile time improvement.

I don't believe any compilers we're supporting with Bazel currently
require this flag, and if they do we should find out and pass it very
narrowly for those compilers. First step is to remove it here.

I've tested this both on a recent Clang and GCC 5 successfully.