### PR TITLE
Cleanups to Clang build.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -329,9 +329,9 @@ cc_library(
         "include/clang/Basic/Version.inc",
         "include/clang/Config/config.h",
     ],
-    defines = [
-        "_GNU_SOURCE",  # Needed for <string.h> to include strdup()
-        "CLANG_ENABLE_REWRITER",
+    deps = [
+        # We rely on the LLVM config library to provide configuration defines.
+        "//llvm:config",
     ],
     includes = ["include"],
 )

--- a/llvm-bazel/llvm-project-overlay/clang/include/clang/Config/config.h
+++ b/llvm-bazel/llvm-project-overlay/clang/include/clang/Config/config.h
@@ -1,4 +1,18 @@
-/* This generated file is for internal use. Do not include it from headers. */
+/*===------- clang/Config/config.h - llvm configuration -----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+/* This is a manual port of config.h.cmake for the symbols that do not change
+   based on platform. Those that do change should not be defined here and
+   instead use Bazel cc_library defines. Some attempt has been made to extract
+   such symbols that do vary based on platform (for the platforms we care about)
+   into Bazel defines, but it is by no means complete, so if you see something
+   that looks wrong, it probably is. */
 
 #ifdef CLANG_CONFIG_H
 #error config.h can only be included once

--- a/llvm-bazel/llvm-project-overlay/llvm/config.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/config.bzl
@@ -33,6 +33,7 @@ posix_defines = [
 ]
 
 linux_defines = posix_defines + [
+    "_GNU_SOURCE",
     "HAVE_LINK_H=1",
     "HAVE_LSEEK64=1",
     "HAVE_MALLINFO=1",


### PR DESCRIPTION
This removes a stale define, sinks another into the configuration layer
where it belongs, connects that configuration layer more cleanly, and
adds the file header that was requested but seems to have not actually
landed in the original PR.