### PR TITLE
Remove most of the remaining include search hacks.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -330,11 +330,11 @@ cc_library(
         "include/clang/Basic/Version.inc",
         "include/clang/Config/config.h",
     ],
+    includes = ["include"],
     deps = [
         # We rely on the LLVM config library to provide configuration defines.
         "//llvm:config",
     ],
-    includes = ["include"],
 )
 
 # TODO: This should get replaced with something that actually generates the
@@ -346,6 +346,19 @@ genrule(
     # the other includes.
     outs = ["include/VCSVersion.inc"],
     cmd = "echo \"#define CLANG_REVISION \\\"git\\\"\" > $@",
+)
+
+# A hacky library to expose some internal headers of the `basic` library to its
+# own implementation source files using a stripped include prefix rather than
+# file-relative-inclusion. This is inherently non-modular as these headers will
+# be repeated in the sources below for file-relative-inclusion.
+cc_library(
+    name = "basic_internal_headers",
+    hdrs = glob([
+        "lib/Basic/*.h",
+    ]),
+    features = ["-header_modules"],
+    strip_include_prefix = "lib/Basic",
 )
 
 cc_library(
@@ -365,10 +378,6 @@ cc_library(
     ]),
     copts = [
         "-DHAVE_VCS_VERSION_INC",
-        # TODO: Would be good to remove the odd #include lines within the
-        # implementation of the basic library that require this. Specifying the
-        # exact path to the library this way relies on Bazel internals.
-        "-Iexternal/llvm-project/clang/lib/Basic",
         "$(STACK_FRAME_UNLIMITED)",
     ],
     includes = ["include"],
@@ -410,6 +419,7 @@ cc_library(
         ":basic_arm_sve_builtins_gen",
         ":basic_arm_sve_typeflags_gen",
         ":basic_attr_gen",
+        ":basic_internal_headers",
         ":config",
         ":diagnostic_defs_gen",
         ":sema_attr_gen",

--- a/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
@@ -141,10 +141,10 @@ cc_test(
     srcs = glob([
         "Format/*.cpp",
         "Format/*.h",
+        "Tooling/*.h",
     ]),
     copts = ["$(STACK_FRAME_UNLIMITED)"],
     deps = [
-        ":tooling_tests_hdrs",
         "//clang:basic",
         "//clang:format",
         "//clang:frontend",
@@ -197,24 +197,35 @@ cc_test(
     ],
 )
 
+# A library to carefully expose the tooling headers using the include prefix
+# expected by the `rename_tests`.
+cc_library(
+    name = "rename_tests_tooling_hdrs",
+    testonly = 1,
+    hdrs = glob(["Tooling/*.h"]),
+    include_prefix = "unittests",
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:frontend",
+        "//clang:rewrite",
+        "//clang:tooling",
+        "//clang:tooling_core",
+        "//llvm:Support",
+        "//llvm:gtest",
+    ],
+)
+
 cc_test(
     name = "rename_tests",
     size = "small",
     timeout = "moderate",
-    srcs = glob(
-        [
-            "Rename/*.cpp",
-            "Rename/*.h",
-        ],
-    ),
-    copts = [
-        # TODO: The `:tooling_test_hdrs` are reached using include paths that
-        # need this, but it would be better to restructure things so they could
-        # have a more natural location and not rely on a Bazel internal.
-        "-Iexternal/llvm-project/clang",
-    ],
+    srcs = glob([
+        "Rename/*.cpp",
+        "Rename/*.h",
+    ]),
     deps = [
-        ":tooling_tests_hdrs",
+        ":rename_tests_tooling_hdrs",
         "//clang:ast_matchers",
         "//clang:basic",
         "//clang:format",
@@ -298,28 +309,14 @@ cc_test(
     ],
 )
 
-cc_library(
-    name = "tooling_tests_hdrs",
-    testonly = 1,
-    hdrs = glob(["Tooling/*.h"]),
-    deps = [
-        "//clang:ast",
-        "//clang:basic",
-        "//clang:frontend",
-        "//clang:rewrite",
-        "//clang:tooling",
-        "//clang:tooling_core",
-        "//llvm:Support",
-        "//llvm:gtest",
-    ],
-)
-
 cc_test(
     name = "tooling_tests",
     size = "medium",
-    srcs = glob(["Tooling/*.cpp"]),
+    srcs = glob([
+        "Tooling/*.cpp",
+        "Tooling/*.h",
+    ]),
     deps = [
-        ":tooling_tests_hdrs",
         "//clang:ast",
         "//clang:ast_matchers",
         "//clang:basic",
@@ -340,19 +337,33 @@ cc_test(
     ],
 )
 
+# A library to carefully expose the tooling headers using the include prefix
+# expected by the `tooling_recursive_ast_visitor_tests`.
+cc_library(
+    name = "tooling_recursive_ast_visitor_tests_tooling_hdrs",
+    testonly = 1,
+    hdrs = glob(["Tooling/*.h"]),
+    strip_include_prefix = "Tooling",
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:frontend",
+        "//clang:rewrite",
+        "//clang:tooling",
+        "//clang:tooling_core",
+        "//llvm:Support",
+        "//llvm:gtest",
+    ],
+)
+
 cc_test(
     name = "tooling_recursive_ast_visitor_tests",
     size = "medium",
     srcs = glob(["Tooling/RecursiveASTVisitorTests/*.cpp"]) + [
         "Tooling/RecursiveASTVisitorTests/CallbacksCommon.h",
     ],
-    copts = [
-        # TOOD: Would be nice to rework the headers here to avoid the need for
-        # this and relying on Bazel internals.
-        "-Iexternal/llvm-project/clang/unittests/Tooling",
-    ],
     deps = [
-        ":tooling_tests_hdrs",
+        ":tooling_recursive_ast_visitor_tests_tooling_hdrs",
         "//clang:ast",
         "//clang:basic",
         "//clang:frontend",

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2177,6 +2177,22 @@ cc_library(
     ],
 )
 
+# FIXME: This library should use `textual_hdrs` instead of `hdrs` as we don't
+# want to parse or build modules for them (and haven't duplicated the necessary
+# dependencies), but unfortunately that doesn't work with
+# `strip_include_prefix`: https://github.com/bazelbuild/bazel/issues/12424
+#
+# For now, we simply disable features that might rely on the headers parsing.
+cc_library(
+    name = "llvm-objcopy-headers",
+    hdrs = glob(["tools/llvm-objcopy/**/*.h"]),
+    features = [
+        "-parse_headers",
+        "-header_modules",
+    ],
+    strip_include_prefix = "tools/llvm-objcopy",
+)
+
 cc_library(
     name = "MCA",
     srcs = glob([
@@ -2193,6 +2209,15 @@ cc_library(
         ":Object",
         ":Support",
     ],
+)
+
+cc_library(
+    name = "llvm-mca-headers",
+    hdrs = glob([
+        "tools/llvm-mca/*.h",
+        "tools/llvm-mca/Views/*.h",
+    ]),
+    strip_include_prefix = "tools/llvm-mca",
 )
 
 cc_library(
@@ -2215,10 +2240,19 @@ cc_library(
         "tools/llvm-exegesis/lib/*.cpp",
         "tools/llvm-exegesis/lib/X86/*.cpp",
         "tools/llvm-exegesis/lib/X86/*.h",
+
+        # We have to include these headers here as well as in the `hdrs` below
+        # to allow the `.cpp` files to use file-relative-inclusion to find
+        # them, even though consumers of this library use inclusion relative to
+        # `tools/llvm-exegesis/lib` with the `strip_includes_prefix` of this
+        # library. This mixture appears to be incompatible with header modules.
+        "tools/llvm-exegesis/lib/*.h",
     ]),
     hdrs = glob(["tools/llvm-exegesis/lib/*.h"]),
     copts = llvm_copts + ["-DHAVE_LIBPFM=1"],
     defines = ["LLVM_EXEGESIS_INITIALIZE_NATIVE_TARGET=InitializeX86ExegesisTarget"],
+    features = ["-header_modules"],
+    strip_include_prefix = "tools/llvm-exegesis/lib",
     tags = [
         "manual",  # External dependency (libpfm4)
         "nobuildkite",  # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.
@@ -2617,6 +2651,7 @@ cc_binary(
         "tools/llvm-exegesis/llvm-exegesis.cpp",
     ],
     copts = llvm_copts + ["-DHAVE_LIBPFM=0"],
+    linkopts = ["-lpfm"],
     stamp = 0,
     tags = [
         "manual",  # TODO(chandlerc): Enable when the library builds.
@@ -2836,11 +2871,9 @@ cc_binary(
     name = "llvm-mca",
     srcs = glob([
         "tools/llvm-mca/*.cpp",
-        "tools/llvm-mca/*.h",
         "tools/llvm-mca/Views/*.cpp",
-        "tools/llvm-mca/Views/*.h",
     ]),
-    copts = llvm_copts + ["-Iexternal/llvm-project/llvm/tools/llvm-mca"],
+    copts = llvm_copts,
     stamp = 0,
     deps = [
         ":AllTargetsAsmParsers",
@@ -2850,6 +2883,7 @@ cc_binary(
         ":MCA",
         ":MCParser",
         ":Support",
+        ":llvm-mca-headers",
     ],
 )
 
@@ -2995,22 +3029,6 @@ gentbl(
     td_srcs = [
         "include/llvm/Option/OptParser.td",
         "tools/llvm-objcopy/CommonOpts.td",
-    ],
-)
-
-# FIXME: This library should use `textual_hdrs` instead of `hdrs` as we don't
-# want to parse or build modules for them (and haven't duplicated the necessary
-# dependencies), but unfortunately that doesn't work with
-# `strip_include_prefix`: https://github.com/bazelbuild/bazel/issues/12424
-#
-# For now, we simply disable features that might rely on the headers parsing.
-cc_library(
-    name = "llvm-objcopy-headers",
-    hdrs = glob(["tools/llvm-objcopy/**/*.h"]),
-    strip_include_prefix = "tools/llvm-objcopy",
-    features = [
-        "-parse_headers",
-        "-header_modules",
     ],
 )
 
@@ -3447,6 +3465,26 @@ cc_library(
     ],
 )
 
+# A hacky library to expose some internal headers of gtest to its own
+# implementation source files using a stripped include prefix rather than
+# file-relative-inclusion.
+#
+# FIXME: This file should be in `textual_hdrs` instead of `hdrs`, but
+# unfortunately that doesn't work with `strip_include_prefix`:
+# https://github.com/bazelbuild/bazel/issues/12424
+#
+# For now, simply disable parsing and header modules.
+cc_library(
+    name = "gtest_internal_headers",
+    testonly = True,
+    hdrs = ["utils/unittest/googletest/src/gtest-internal-inl.h"],
+    features = [
+        "-parse_headers",
+        "-header_modules",
+    ],
+    strip_include_prefix = "utils/unittest/googletest",
+)
+
 cc_library(
     name = "gtest",
     testonly = True,
@@ -3462,11 +3500,7 @@ cc_library(
     ) + [
     ],
     hdrs = ["utils/unittest/googletest/include/gtest/gtest.h"],
-    # TODO: the hard-coding of `external/llvm-project` path components here is
-    # really unfortunate. It is essentially baking in an implementation detail
-    # of how Bazel runs the compiler when compiling LLVM in the exact
-    # configuration we use.
-    copts = llvm_copts + ["-Iexternal/llvm-project/llvm/utils/unittest/googletest"],
+    copts = llvm_copts,
     defines = [
         "GTEST_HAS_RTTI=0",
         "__STDC_LIMIT_MACROS",
@@ -3481,9 +3515,11 @@ cc_library(
     ],
     textual_hdrs = [
         "utils/unittest/googletest/include/gtest/gtest_pred_impl.h",
-        "utils/unittest/googletest/src/gtest-internal-inl.h",
     ],
-    deps = [":Support"],
+    deps = [
+        ":Support",
+        ":gtest_internal_headers",
+    ],
 )
 
 cc_library(
@@ -3509,11 +3545,7 @@ cc_library(
         exclude = ["utils/unittest/googlemock/src/gmock-all.cc"],
     ),
     hdrs = ["utils/unittest/googlemock/include/gmock/gmock.h"],
-    # TODO: the hard-coding of `external/llvm-project` path components here is
-    # really unfortunate. It is essentially baking in an implementation detail
-    # of how Bazel runs the compiler when compiling LLVM in the exact
-    # configuration we use.
-    copts = llvm_copts + ["-Iexternal/llvm-project/llvm/utils/unittest/googlemock"],
+    copts = llvm_copts,
     includes = [
         "include",
         "utils/unittest/googlemock/include",

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -565,10 +565,8 @@ cc_test(
     ]) + [
         "tools/llvm-exegesis/Common/AssemblerUtils.h",
     ],
-    copts = [
-        "-Iexternal/llvm-project/llvm/tools/llvm-exegesis/lib/",
-        "-DHAVE_LIBPFM=1",
-    ],
+    copts = ["-DHAVE_LIBPFM=1"],
+    linkopts = ["-lpfm"],
     tags = [
         "manual",  # External dependency (libpfm4)
         "nobuildkite",  # TODO(chandlerc): Add support for fetching and building libpfm4 and enable this.


### PR DESCRIPTION
Notably, all of the `-Iexternal/...` tricks are gone through the careful
application of extra entries in `srcs` to enable
file-relative-inclusion, and special header-only libraries which
re-expose header files with the desired prefixes using combinations of
`strip_include_prefix` and in one case `include_prefix`.

The result likely has some missing dependencies that will only be
detected if we enable header parsing in the future. I didn't want to try
to figure those out from scratch in every case without the tooling to
tell me if I'm wrong.

There are also still places where we should be doing intentional textual
headers, but cannot due to the Bazel bug that prevents
`strip_include_prefix` from working with them. I've left appropriate
comments about fixing those.

Even with the workarounds required here, I think this is a positive
step, and I don't really want to block on cleaning up all the code that
this copes with.

I also had to fix some of the build issues with the `llvm-exegesis`
stuff that I hadn't noticed before in order to test all of this, but
I did and that's included. The unittests and everything for that builds
now if you happen to have the correct stuff installed locally.