### PR TITLE
Cleanup `buildifer` formatting and lint warnings.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//llvm:tblgen.bzl", "gentbl")
 load("//llvm:binary_alias.bzl", "binary_alias")
 
@@ -710,8 +711,8 @@ cc_library(
 cc_library(
     name = "index",
     srcs = glob([
-            "lib/Index/*.cpp",
-            "lib/Index/*.h",
+        "lib/Index/*.cpp",
+        "lib/Index/*.h",
     ]),
     hdrs = glob([
         "include/clang/Index/*.h",
@@ -800,14 +801,6 @@ cc_library(
     ]),
     copts = ["$(STACK_FRAME_UNLIMITED)"],
     includes = ["include"],
-    textual_hdrs = glob([
-        "include/clang/Sema/AttrParsedAttrImpl.inc",
-        "include/clang/Sema/AttrParsedAttrKinds.inc",
-        "include/clang/Sema/AttrParsedAttrList.inc",
-        "include/clang/Sema/AttrSpellingListIndex.inc",
-        "include/clang/Sema/AttrTemplateInstantiate.inc",
-        "lib/Sema/OpenCLBuiltins.inc",
-    ]),
     deps = [
         ":analysis",
         ":ast",
@@ -1103,9 +1096,10 @@ cc_library(
     ),
     hdrs = glob([
         "include/clang/Format/*.h",
+    ]) + [
         "lib/Format/FormatTokenLexer.h",
         "lib/Format/Macros.h",
-    ]),
+    ],
     includes = ["include"],
     deps = [
         ":basic",
@@ -1549,10 +1543,8 @@ gentbl(
 cc_library(
     name = "serialization",
     srcs = glob([
-        "lib/Serialization/*.cp" + "p",
+        "lib/Serialization/*.cpp",
         "lib/Serialization/*.h",
-        "include/clang/Serialization/AttrPCHRead.inc",
-        "include/clang/Serialization/AttrPCHWrite.inc",
     ]),
     hdrs = glob([
         "include/clang/Serialization/*.h",

--- a/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
@@ -2,6 +2,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load(":template_rule.bzl", "template_rule")
 load(":tblgen.bzl", "gentbl")
 load(":config.bzl", "llvm_config_defines")

--- a/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
@@ -12,6 +12,8 @@ TODO(chandlerc): Currently this expresses include-based dependencies as
 correctly understood by the build system.
 """
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 def gentbl(name, tblgen, td_file, td_srcs, tbl_outs, library = True, **kwargs):
     """gentbl() generates tabular code from a table definition file.
 
@@ -27,7 +29,7 @@ def gentbl(name, tblgen, td_file, td_srcs, tbl_outs, library = True, **kwargs):
       **kwargs: Keyword arguments to pass to subsidiary cc_library() rule.
     """
     if td_file not in td_srcs:
-        td_srcs += [td_file]
+        td_srcs.append(td_file)
     for (opts, out) in tbl_outs:
         rule_suffix = "_".join(opts.replace("-", "_").replace("=", "_").split(" "))
         native.genrule(
@@ -51,7 +53,7 @@ def gentbl(name, tblgen, td_file, td_srcs, tbl_outs, library = True, **kwargs):
     # If this is not true, you should specify library = False
     # and list the generated '.inc' files in "srcs".
     if library:
-        native.cc_library(
+        cc_library(
             name = name,
             # FIXME: This should be `textual_hdrs` instead of `hdrs`, but
             # unfortunately that doesn't work with `strip_include_prefix`:

--- a/llvm-bazel/llvm-project-overlay/llvm/template_rule.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/template_rule.bzl
@@ -2,27 +2,29 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Rule for simple expansion of template files. This performs a simple
-# search over the template file for the keys in substitutions,
-# and replaces them with the corresponding values.
-#
-# Typical usage:
-#   load("/tools/build_rules/template_rule", "expand_header_template")
-#   template_rule(
-#       name = "ExpandMyTemplate",
-#       src = "my.template",
-#       out = "my.txt",
-#       substitutions = {
-#         "$VAR1": "foo",
-#         "$VAR2": "bar",
-#       }
-#   )
-#
-# Args:
-#   name: The name of the rule.
-#   template: The template file to expand
-#   out: The destination of the expanded file
-#   substitutions: A dictionary mapping strings to their substitutions
+"""Rule for simple expansion of template files.
+
+This performs a simple search over the template file for the keys in
+substitutions, and replaces them with the corresponding values.
+
+Typical usage:
+  load("/tools/build_rules/template_rule", "expand_header_template")
+  template_rule(
+      name = "ExpandMyTemplate",
+      src = "my.template",
+      out = "my.txt",
+      substitutions = {
+        "$VAR1": "foo",
+        "$VAR2": "bar",
+      }
+  )
+
+Args:
+  name: The name of the rule.
+  template: The template file to expand
+  out: The destination of the expanded file
+  substitutions: A dictionary mapping strings to their substitutions
+"""
 
 def template_rule_impl(ctx):
     ctx.actions.expand_template(

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//llvm:tblgen.bzl", "gentbl")
 
 package(
@@ -252,8 +253,9 @@ cc_test(
     srcs = glob([
         "IR/*.cpp",
         "IR/*.h",
+    ]) + [
         "Support/KnownBitsTest.h",
-    ]),
+    ],
     deps = [
         "//llvm:Analysis",
         "//llvm:AsmParser",
@@ -470,7 +472,7 @@ cc_test(
     ],
     linkstatic = 1,
     tags = [
-        "local", # Not compatible with the sandbox on MacOS
+        "local",  # Not compatible with the sandbox on MacOS
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -5,6 +5,7 @@
 # Description:
 #   The MLIR "Multi-Level Intermediate Representation" Compiler Infrastructure
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load(":tblgen.bzl", "gentbl")
 load(":linalggen.bzl", "genlinalg")
 
@@ -844,10 +845,10 @@ cc_library(
 filegroup(
     name = "ShapeOpsTdFiles",
     srcs = [
-        ":StdOpsTdFiles",
         "include/mlir/Dialect/Shape/IR/ShapeBase.td",
         "include/mlir/Dialect/Shape/IR/ShapeOps.td",
         "include/mlir/Interfaces/InferTypeOpInterface.td",
+        ":StdOpsTdFiles",
     ],
 )
 
@@ -932,7 +933,6 @@ gentbl(
         ":ShapeOpsTdFiles",
     ],
 )
-
 
 cc_library(
     name = "ShapeToStandard",
@@ -1387,9 +1387,7 @@ cc_library(
             "lib/Dialect/GPU/IR/*.h",
         ],
     ),
-    hdrs = glob([
-        "include/mlir/Dialect/GPU/GPUDialect.h",
-    ]),
+    hdrs = ["include/mlir/Dialect/GPU/GPUDialect.h"],
     includes = ["include"],
     deps = [
         ":GPUBaseIncGen",
@@ -3569,9 +3567,7 @@ cc_binary(
 
 cc_binary(
     name = "mlir-linalg-ods-gen",
-    srcs = glob([
-        "tools/mlir-linalg-ods-gen/mlir-linalg-ods-gen.cpp",
-    ]),
+    srcs = glob(["tools/mlir-linalg-ods-gen/*.cpp"]),
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [

--- a/llvm-bazel/llvm-project-overlay/mlir/linalggen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/linalggen.bzl
@@ -4,6 +4,8 @@
 
 """BUILD extensions for MLIR linalg generation."""
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 def genlinalg(name, linalggen, src, linalg_outs):
     """genlinalg() generates code from a tc spec file.
 
@@ -36,7 +38,7 @@ def genlinalg(name, linalggen, src, linalg_outs):
 
     # List of opts that do not generate cc files.
     hdrs = [f for (opts, f) in linalg_outs]
-    native.cc_library(
+    cc_library(
         name = name,
         hdrs = hdrs,
         textual_hdrs = hdrs,

--- a/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -4,6 +4,8 @@
 
 """BUILD extensions for MLIR table generation."""
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 def gentbl(name, tblgen, td_file, tbl_outs, td_srcs = [], td_includes = [], td_relative_includes = [], strip_include_prefix = None, test = False):
     """gentbl() generates tabular code from a table definition file.
 
@@ -89,7 +91,7 @@ def gentbl(name, tblgen, td_file, tbl_outs, td_srcs = [], td_includes = [], td_r
     # List of opts that do not generate cc files.
     skip_opts = ["-gen-op-doc"]
     hdrs = [f for (opts, f) in tbl_outs if opts not in skip_opts]
-    native.cc_library(
+    cc_library(
         name = name,
         # include_prefix does not apply to textual_hdrs.
         hdrs = hdrs if strip_include_prefix else [],

--- a/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//mlir:tblgen.bzl", "gentbl")
 
 package(


### PR DESCRIPTION
These aren't all trivial -- several of these showed questionable globs
that I've tried to fix in the way that seemed most effective.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/llvm-bazel/84)
<!-- Reviewable:end -->
