### PR TITLE
Set --long-string-literals=0 on Windows in tblgen.bzl again.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -1654,6 +1654,12 @@ gentbl(
         strip_include_prefix = "lib/Target/" + target["name"],
         tbl_outs = target["tbl_outs"],
         tblgen = ":llvm-tblgen",
+        # MSVC isn't happy with long string literals, while other compilers
+        # which support them get significant compile time improvements with
+        # them enabled. Ideally this flag would only be enabled on Windows via
+        # a select() on `@bazel_tools//src/conditions:windows,`, but that would
+        # require refactoring gentbl from a macro into a rule.
+        tblgen_args = "--long-string-literals=0",
         td_file = "lib/Target/" + target["name"] + "/" + target["short_name"] + ".td",
         td_srcs = [
             ":common_target_td_sources",

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -1659,6 +1659,7 @@ gentbl(
         # them enabled. Ideally this flag would only be enabled on Windows via
         # a select() on `@bazel_tools//src/conditions:windows,`, but that would
         # require refactoring gentbl from a macro into a rule.
+        # TODO(#92): Refactor gentbl to support this use
         tblgen_args = "--long-string-literals=0",
         td_file = "lib/Target/" + target["name"] + "/" + target["short_name"] + ".td",
         td_srcs = [

--- a/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
@@ -36,15 +36,30 @@ def gentbl(name, tblgen, td_file, td_srcs, tbl_outs, library = True, **kwargs):
             outs = [out],
             tools = [tblgen],
             message = "Generating code from table: %s" % td_file,
-            cmd = (("$(location %s) -I external/llvm-project/llvm/include " +
-                    "-I external/llvm-project/clang/include " +
-                    "-I $$(dirname $(location %s)) " +
-                    "%s $(location %s) -o $@") % (
-                tblgen,
-                td_file,
-                opts,
-                td_file,
-            )),
+            # MSVC isn't happy with long string literals, while other compilers
+            # which support them get significant compile time improvements with
+            # them enabled.
+            # See https://github.com/google/llvm-bazel/pull/71 for context.
+            cmd = select({
+                "@bazel_tools//src/conditions:windows": (("$(location %s) -I external/llvm-project/llvm/include " +
+                                                          "-I external/llvm-project/clang/include " +
+                                                          "-I $$(dirname $(location %s)) " +
+                                                          "%s $(location %s) --long-string-literals=0 -o $@") % (
+                    tblgen,
+                    td_file,
+                    opts,
+                    td_file,
+                )),
+                "//conditions:default": (("$(location %s) -I external/llvm-project/llvm/include " +
+                                          "-I external/llvm-project/clang/include " +
+                                          "-I $$(dirname $(location %s)) " +
+                                          "%s $(location %s) -o $@") % (
+                    tblgen,
+                    td_file,
+                    opts,
+                    td_file,
+                )),
+            }),
         )
 
     # For now, all generated files can be assumed to comprise public interfaces.


### PR DESCRIPTION
This fixes a build failure on MSVC introduced by https://github.com/google/llvm-bazel/pull/71. See https://github.com/google/llvm-bazel/pull/71#issuecomment-724276137 and https://github.com/google/iree/issues/3756 for context.