### PR TITLE
Shard slow unit tests

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -102,7 +102,7 @@ build:rbe --remote_instance_name=projects/llvm-bazel/instances/default_instance
 # this higher can make builds faster by allowing more jobs to run in parallel.
 # Setting it too high can result in jobs that timeout, however, while waiting
 # for a remote machine to execute them.
-build:rbe --jobs=50
+build:rbe --jobs=150
 
 # Set several flags related to specifying the platform, toolchain and java
 # properties.

--- a/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
@@ -14,7 +14,7 @@ cc_test(
         "AST/*.cpp",
         "AST/*.h",
     ]),
-    shard_count = len(glob(["AST/*Test.cpp"])),
+    shard_count = 20,
     deps = [
         "//clang:ast",
         "//clang:ast_matchers",
@@ -49,7 +49,7 @@ cc_test(
     name = "ast_matchers_tests",
     size = "medium",
     srcs = glob(["ASTMatchers/*.cpp"]),
-    shard_count = len(glob(["ASTMatchers/*Test.cpp"])),
+    shard_count = 20,
     deps = [
         ":ast_matchers_tests_hdrs",
         "//clang:ast",
@@ -145,7 +145,7 @@ cc_test(
         "Tooling/*.h",
     ]),
     copts = ["$(STACK_FRAME_UNLIMITED)"],
-    shard_count = len(glob(["Format/*Test.cpp"])),
+    shard_count = 20,
     deps = [
         "//clang:basic",
         "//clang:format",
@@ -226,7 +226,7 @@ cc_test(
         "Rename/*.cpp",
         "Rename/*.h",
     ]),
-    shard_count = len(glob(["Rename/*Test.cpp"])),
+    shard_count = 20,
     deps = [
         ":rename_tests_tooling_hdrs",
         "//clang:ast_matchers",
@@ -319,6 +319,7 @@ cc_test(
         "Tooling/*.cpp",
         "Tooling/*.h",
     ]),
+    shard_count = 20,
     deps = [
         "//clang:ast",
         "//clang:ast_matchers",
@@ -388,6 +389,7 @@ cc_test(
         "Tooling/Syntax/*.cpp",
         "Tooling/Syntax/*.h",
     ]),
+    shard_count = 20,
     deps = [
         "//clang:ast",
         "//clang:basic",

--- a/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
@@ -10,11 +10,11 @@ package(
 cc_test(
     name = "ast_tests",
     size = "medium",
-    timeout = "long",
     srcs = glob([
         "AST/*.cpp",
         "AST/*.h",
     ]),
+    shard_count = len(glob(["AST/*Test.cpp"])),
     deps = [
         "//clang:ast",
         "//clang:ast_matchers",
@@ -47,8 +47,9 @@ cc_library(
 
 cc_test(
     name = "ast_matchers_tests",
-    size = "large",
+    size = "medium",
     srcs = glob(["ASTMatchers/*.cpp"]),
+    shard_count = len(glob(["ASTMatchers/*Test.cpp"])),
     deps = [
         ":ast_matchers_tests_hdrs",
         "//clang:ast",
@@ -144,6 +145,7 @@ cc_test(
         "Tooling/*.h",
     ]),
     copts = ["$(STACK_FRAME_UNLIMITED)"],
+    shard_count = len(glob(["Format/*Test.cpp"])),
     deps = [
         "//clang:basic",
         "//clang:format",
@@ -224,6 +226,7 @@ cc_test(
         "Rename/*.cpp",
         "Rename/*.h",
     ]),
+    shard_count = len(glob(["Rename/*Test.cpp"])),
     deps = [
         ":rename_tests_tooling_hdrs",
         "//clang:ast_matchers",

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -16,6 +16,7 @@ cc_test(
         "ADT/*.cpp",
         "ADT/*.h",
     ]),
+    shard_count = 20,
     deps = [
         "//llvm:Core",
         "//llvm:Support",
@@ -254,6 +255,7 @@ cc_test(
         "IR/*.h",
         "Support/KnownBitsTest.h",
     ]),
+    shard_count = 20,
     deps = [
         "//llvm:Analysis",
         "//llvm:AsmParser",
@@ -470,7 +472,7 @@ cc_test(
     ],
     linkstatic = 1,
     tags = [
-        "local", # Not compatible with the sandbox on MacOS
+        "local",  # Not compatible with the sandbox on MacOS
     ],
     visibility = ["//visibility:private"],
     deps = [


### PR DESCRIPTION
These tests are big and take a long time. If you have the appropriate
fanout, it's pretty painful to wait several minutes just because we've
globbed together a bunch of files. The `shard_count` is a pretty much
arbitrary reasonable-seeming choice.

Obviously not everyone has this fanout and sharding isn't free, so I
tried to stick to something not too large. Even without remote build
execution, 20 shards is likely to give you speedups on a reasonably
beefy machine. I also played with a couple other strategies: iterating
over globs to create one test per file, and determining the shard count
based on the number of files. The former doesn't really give us any of
the normal advantages of per-file test rules (which I would usually
prefer, but aren't feasible to maintain for a mostly-unsupported build
system). The latter didn't shard some of the bigger tests enough and we
still ended up with some very slow shards. Both of them also added to
the complexity of the build file.

As part of playing with this, I also increased our RBE worker pool to
150 workers, so increased the job count in the config to match. I can
send that as a separate PR if desirable.