### PR TITLE
Move turnstyle timeout into the step

### DIFF
--- a/.github/workflows/auto_integrate.yml
+++ b/.github/workflows/auto_integrate.yml
@@ -21,8 +21,6 @@ jobs:
     # Don't run on forks
     if: github.repository == 'google/llvm-bazel'
     runs-on: ubuntu-18.04
-    # Mostly so that busy-waiting through turnstyle is not indefinite.
-    timeout-minutes: 15
     env:
       MERGING_BRANCH: "main"
       INTEGRATION_BRANCH: "auto-integrate"
@@ -35,6 +33,7 @@ jobs:
         uses: softprops/turnstyle@v1
         with:
           same-branch-only: false
+          abort-after-seconds: 900
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checking out repository


### PR DESCRIPTION
Now possible with the introduction of `abort-after-seconds` in
https://github.com/softprops/turnstyle/pull/19. We've had a few
timeouts recently because the main branch got far behind `HEAD`.