### PR TITLE
Integrate LLVM at llvm/llvm-project@ea4d24c899ea

### DIFF
--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -710,8 +710,8 @@ cc_library(
 cc_library(
     name = "index",
     srcs = glob([
-            "lib/Index/*.cpp",
-            "lib/Index/*.h",
+        "lib/Index/*.cpp",
+        "lib/Index/*.h",
     ]),
     hdrs = glob([
         "include/clang/Index/*.h",
@@ -1025,6 +1025,20 @@ cc_library(
     ],
 )
 
+gentbl(
+    name = "tooling_syntax_nodes_gen",
+    tbl_outs = [
+        ("-gen-clang-syntax-node-list", "include/clang/Tooling/Syntax/Nodes.inc"),
+        ("-gen-clang-syntax-node-classes", "include/clang/Tooling/Syntax/NodeClasses.inc"),
+    ],
+    tblgen = ":clang-tblgen",
+    td_file = "include/clang/Tooling/Syntax/Nodes.td",
+    td_srcs = [
+        "include/clang/Tooling/Syntax/Nodes.td",
+        "include/clang/Tooling/Syntax/Syntax.td",
+    ],
+)
+
 cc_library(
     name = "tooling_syntax",
     srcs = glob(["lib/Tooling/Syntax/**/*.cpp"]),
@@ -1034,6 +1048,7 @@ cc_library(
         ":basic",
         ":lex",
         ":tooling_core",
+        ":tooling_syntax_nodes_gen",
         "//llvm:Support",
     ],
 )

--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -1026,7 +1026,7 @@ cc_library(
 )
 
 gentbl(
-    name = "tooling_syntax_nodes_gen",
+    name = "tooling_syntax_gen",
     tbl_outs = [
         ("-gen-clang-syntax-node-list", "include/clang/Tooling/Syntax/Nodes.inc"),
         ("-gen-clang-syntax-node-classes", "include/clang/Tooling/Syntax/NodeClasses.inc"),
@@ -1048,7 +1048,7 @@ cc_library(
         ":basic",
         ":lex",
         ":tooling_core",
-        ":tooling_syntax_nodes_gen",
+        ":tooling_syntax_gen",
         "//llvm:Support",
     ],
 )


### PR DESCRIPTION
Update BUILD files and submodule for
[ea4d24c899ea](https://github.com/llvm/llvm-project/commit/ea4d24c899ea)

This bundles BUILD file changes for a few commits related to syntax
tooling.