### PR TITLE
Integrate LLVM at llvm/llvm-project@68f53960e17d

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -2049,16 +2049,26 @@ cc_library(
     ],
 )
 
+# There is some deep layering violation between these libraries and JITLink.
+# To workaround this, the same headers are included in multiple rules.
+cc_library(
+    name = "Orc_layering_violation_headers",
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/Orc/*.h",
+        "include/llvm/ExecutionEngine/Orc/RPC/*.h",
+        "include/llvm/ExecutionEngine/JITLink/*.h",
+    ]),
+)
+
 cc_library(
     name = "OrcJIT",
     srcs = glob([
         "lib/ExecutionEngine/Orc/*.cpp",
         "lib/ExecutionEngine/Orc/*.h",
-        "lib/ExecutionEngine/Orc/RPC/*.cpp",
-        "lib/ExecutionEngine/OrcError/*.cpp",
     ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/*.h",
+        "include/llvm/ExecutionEngine/Orc/RPC/*.h",
     ]) + [
         "include/llvm-c/LLJIT.h",
         "include/llvm-c/Orc.h",
@@ -2073,6 +2083,7 @@ cc_library(
         ":JITLink",
         ":MC",
         ":Object",
+        ":OrcShared",
         ":OrcTargetProcess",
         ":Support",
         ":Target",
@@ -2087,9 +2098,7 @@ cc_library(
         "lib/ExecutionEngine/Orc/Shared/*.cpp",
     ]),
     hdrs = glob([
-        "include/llvm/ExecutionEngine/Orc/RPC/*.h",
         "include/llvm/ExecutionEngine/Orc/Shared/*.h",
-        "include/llvm/ExecutionEngine/Orc/*.h",
     ]),
     copts = llvm_copts,
     deps = [
@@ -2101,6 +2110,7 @@ cc_library(
         ":MC",
         ":MCDisassembler",
         ":Object",
+        ":Orc_layering_violation_headers",
         ":Passes",
         ":Support",
         ":Target",
@@ -2115,7 +2125,6 @@ cc_library(
     ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/TargetProcess/*.h",
-        "include/llvm/ExecutionEngine/Orc/*.h",
     ]),
     copts = llvm_copts,
     deps = [
@@ -2128,6 +2137,7 @@ cc_library(
         ":MCDisassembler",
         ":Object",
         ":OrcShared",
+        ":Orc_layering_violation_headers",
         ":Passes",
         ":Support",
         ":Target",


### PR DESCRIPTION
Update BUILD files and submodule for
[68f53960e17d](https://github.com/llvm/llvm-project/commit/68f53960e17d).

This requires working around layering violations in `ExecutionEngine/`.
Here's a dot file graph showing the includes between directories in
`ExecutionEngine/`:
https://gist.github.com/GMNGeoffrey/2c9818d418a70517f8c628432e1c2447