### PR TITLE
Add missing BUILD rules for the OpenACC frontend library.

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -1144,6 +1144,57 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "acc_td_files",
+    srcs = glob([
+        "include/llvm/Frontend/OpenACC/*.td",
+        "include/llvm/Frontend/Directive/*.td",
+    ]),
+)
+
+gentbl(
+    name = "acc_gen",
+    library = False,
+    tbl_outs = [
+        ("--gen-directive-decl", "include/llvm/Frontend/OpenACC/ACC.h.inc"),
+    ],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/Frontend/OpenACC/ACC.td",
+    td_srcs = [":acc_td_files"],
+)
+
+gentbl(
+    name = "acc_gen_impl",
+    library = False,
+    tbl_outs = [
+        ("--gen-directive-gen", "include/llvm/Frontend/OpenACC/ACC.cpp.inc"),
+        ("--gen-directive-impl", "lib/Frontend/OpenACC/ACC.cpp"),
+    ],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/Frontend/OpenACC/ACC.td",
+    td_srcs = [":acc_td_files"],
+)
+
+cc_library(
+    name = "FrontendOpenACC",
+    srcs = glob([
+        "lib/Frontend/OpenACC/*.cpp",
+    ]) + [
+        "include/llvm/Frontend/OpenACC/ACC.cpp.inc",
+        "lib/Frontend/OpenACC/ACC.cpp",
+    ],
+    hdrs = glob([
+        "include/llvm/Frontend/OpenACC/*.h",
+    ]) + ["include/llvm/Frontend/OpenACC/ACC.h.inc"],
+    copts = llvm_copts,
+    deps = [
+        ":Analysis",
+        ":Core",
+        ":Support",
+        ":TransformUtils",
+    ],
+)
+
 cc_library(
     name = "AsmParser",
     srcs = glob([

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -289,6 +289,7 @@ cc_test(
     srcs = glob(["FrontEnd/*.cpp"]),
     deps = [
         "//llvm:Analysis",
+        "//llvm:FrontendOpenACC",
         "//llvm:FrontendOpenMP",
         "//llvm:Passes",
         "//llvm:Support",

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -286,7 +286,7 @@ cc_test(
 cc_test(
     name = "frontend_tests",
     size = "small",
-    srcs = glob(["FrontEnd/*.cpp"]),
+    srcs = glob(["Frontend/*.cpp"]),
     deps = [
         "//llvm:Analysis",
         "//llvm:FrontendOpenACC",


### PR DESCRIPTION
These are only used by one unittest and the Flang frontend currently.
Somehow, the unittest in question compiles and runs successfully on all
the Linux hosts I've tested -- I really don't know how. My best guess is
that it finds the necessary generated header from an LLVM installation
that is made visible even through the sandbox to the build.

However, on MacOS, this doesn't work and the problem surfaces. Fix this
the right way by adding the missing build infrastructure matching the
OMP infrastructure (but simpler given the code simplicity of this
library).

With this, all of the LLVM and Clang unittests build and pass for me on
my Mac laptop.