### PR TITLE
Disallow empty globs in tests

### DIFF
--- a/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/unittests/BUILD
@@ -35,7 +35,10 @@ cc_test(
 cc_library(
     name = "ast_matchers_tests_hdrs",
     testonly = 1,
-    hdrs = glob(["ASTMatchers/*.h"]),
+    hdrs = glob(
+        ["ASTMatchers/*.h"],
+        allow_empty = False,
+    ),
     deps = [
         "//clang:ast_matchers",
         "//clang:frontend",
@@ -48,7 +51,10 @@ cc_library(
 cc_test(
     name = "ast_matchers_tests",
     size = "medium",
-    srcs = glob(["ASTMatchers/*.cpp"]),
+    srcs = glob(
+        ["ASTMatchers/*.cpp"],
+        allow_empty = False,
+    ),
     shard_count = 20,
     deps = [
         ":ast_matchers_tests_hdrs",
@@ -66,7 +72,10 @@ cc_test(
 cc_test(
     name = "ast_matchers_dynamic_tests",
     size = "small",
-    srcs = glob(["ASTMatchers/Dynamic/*.cpp"]),
+    srcs = glob(
+        ["ASTMatchers/Dynamic/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         ":ast_matchers_tests_hdrs",
         "//clang:ast_matchers",
@@ -101,7 +110,10 @@ cc_test(
 cc_test(
     name = "basic_tests",
     size = "small",
-    srcs = glob(["Basic/*.cpp"]),
+    srcs = glob(
+        ["Basic/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//clang:basic",
         "//clang:frontend",
@@ -183,7 +195,10 @@ cc_test(
 cc_test(
     name = "lex_tests",
     size = "small",
-    srcs = glob(["Lex/*.cpp"]),
+    srcs = glob(
+        ["Lex/*.cpp"],
+        allow_empty = False,
+    ),
     copts = ["$(STACK_FRAME_UNLIMITED)"],
     deps = [
         "//clang:ast",
@@ -204,7 +219,10 @@ cc_test(
 cc_library(
     name = "rename_tests_tooling_hdrs",
     testonly = 1,
-    hdrs = glob(["Tooling/*.h"]),
+    hdrs = glob(
+        ["Tooling/*.h"],
+        allow_empty = False,
+    ),
     include_prefix = "unittests",
     deps = [
         "//clang:ast",
@@ -244,7 +262,10 @@ cc_test(
 cc_test(
     name = "rewrite_tests",
     size = "small",
-    srcs = glob(["Rewrite/*.cpp"]),
+    srcs = glob(
+        ["Rewrite/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//clang:rewrite",
         "//clang:tooling",
@@ -256,7 +277,10 @@ cc_test(
 cc_test(
     name = "sema_tests",
     size = "small",
-    srcs = glob(["Sema/*.cpp"]),
+    srcs = glob(
+        ["Sema/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         ":ast_matchers_tests_hdrs",
         "//clang:ast",
@@ -276,7 +300,10 @@ cc_test(
 cc_library(
     name = "static_analyzer_test_headers",
     testonly = 1,
-    hdrs = glob(["StaticAnalyzer/*.h"]),
+    hdrs = glob(
+        ["StaticAnalyzer/*.h"],
+        allow_empty = False,
+    ),
     deps = [
         "//clang:ast_matchers",
         "//clang:crosstu",
@@ -346,7 +373,10 @@ cc_test(
 cc_library(
     name = "tooling_recursive_ast_visitor_tests_tooling_hdrs",
     testonly = 1,
-    hdrs = glob(["Tooling/*.h"]),
+    hdrs = glob(
+        ["Tooling/*.h"],
+        allow_empty = False,
+    ),
     strip_include_prefix = "Tooling",
     deps = [
         "//clang:ast",
@@ -363,7 +393,10 @@ cc_library(
 cc_test(
     name = "tooling_recursive_ast_visitor_tests",
     size = "medium",
-    srcs = glob(["Tooling/RecursiveASTVisitorTests/*.cpp"]) + [
+    srcs = glob(
+        ["Tooling/RecursiveASTVisitorTests/*.cpp"],
+        allow_empty = False,
+    ) + [
         "Tooling/RecursiveASTVisitorTests/CallbacksCommon.h",
     ],
     deps = [
@@ -410,7 +443,10 @@ cc_test(
 cc_test(
     name = "libclang_tests",
     size = "small",
-    srcs = glob(["libclang/*.cpp"]) + [
+    srcs = glob(
+        ["libclang/*.cpp"],
+        allow_empty = False,
+    ) + [
         "libclang/TestUtils.h",
     ],
     deps = [

--- a/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/unittests/BUILD
@@ -51,7 +51,10 @@ cc_test(
 cc_test(
     name = "asm_parser_tests",
     size = "small",
-    srcs = glob(["AsmParser/*.cpp"]),
+    srcs = glob(
+        ["AsmParser/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AsmParser",
         "//llvm:Core",
@@ -64,7 +67,10 @@ cc_test(
 cc_test(
     name = "bitcode_tests",
     size = "small",
-    srcs = glob(["Bitcode/*.cpp"]),
+    srcs = glob(
+        ["Bitcode/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AsmParser",
         "//llvm:BitReader",
@@ -79,7 +85,10 @@ cc_test(
 cc_test(
     name = "bitstream_tests",
     size = "small",
-    srcs = glob(["Bitstream/*.cpp"]),
+    srcs = glob(
+        ["Bitstream/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:BitstreamReader",
         "//llvm:BitstreamWriter",
@@ -91,7 +100,10 @@ cc_test(
 
 cc_library(
     name = "codegen_tests_includes",
-    textual_hdrs = glob(["CodeGen/*.inc"]),
+    textual_hdrs = glob(
+        ["CodeGen/*.inc"],
+        allow_empty = False,
+    ),
 )
 
 cc_test(
@@ -176,7 +188,10 @@ cc_test(
 cc_test(
     name = "execution_engine_tests",
     size = "small",
-    srcs = glob(["ExecutionEngine/*.cpp"]),
+    srcs = glob(
+        ["ExecutionEngine/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AllTargetsCodeGens",
         "//llvm:AsmParser",
@@ -237,7 +252,10 @@ cc_test(
 cc_test(
     name = "filecheck_tests",
     size = "small",
-    srcs = glob(["FileCheck/*.cpp"]),
+    srcs = glob(
+        ["FileCheck/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:FileCheckLib",
         "//llvm:Support",
@@ -274,7 +292,10 @@ cc_test(
 cc_test(
     name = "line_editor_tests",
     size = "small",
-    srcs = glob(["LineEditor/*.cpp"]),
+    srcs = glob(
+        ["LineEditor/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:LineEditor",
         "//llvm:Support",
@@ -286,7 +307,10 @@ cc_test(
 cc_test(
     name = "frontend_tests",
     size = "small",
-    srcs = glob(["Frontend/*.cpp"]),
+    srcs = glob(
+        ["Frontend/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:Analysis",
         "//llvm:FrontendOpenACC",
@@ -301,7 +325,10 @@ cc_test(
 cc_test(
     name = "linker_tests",
     size = "small",
-    srcs = glob(["Linker/*.cpp"]),
+    srcs = glob(
+        ["Linker/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AsmParser",
         "//llvm:Core",
@@ -315,7 +342,10 @@ cc_test(
 cc_test(
     name = "mc_tests",
     size = "small",
-    srcs = glob(["MC/*.cpp"]),
+    srcs = glob(
+        ["MC/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AllTargetsCodeGens",
         "//llvm:AllTargetsDisassemblers",
@@ -330,7 +360,10 @@ cc_test(
 cc_test(
     name = "mi_tests",
     size = "small",
-    srcs = glob(["MI/*.cpp"]),
+    srcs = glob(
+        ["MI/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:AllTargetsAsmParsers",
         "//llvm:AllTargetsCodeGens",
@@ -346,7 +379,10 @@ cc_test(
 cc_test(
     name = "object_tests",
     size = "small",
-    srcs = glob(["Object/*.cpp"]),
+    srcs = glob(
+        ["Object/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:Object",
         "//llvm:ObjectYAML",
@@ -359,7 +395,10 @@ cc_test(
 cc_test(
     name = "object_yaml_tests",
     size = "small",
-    srcs = glob(["ObjectYAML/*.cpp"]),
+    srcs = glob(
+        ["ObjectYAML/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:DebugInfoCodeView",
         "//llvm:Object",
@@ -416,7 +455,10 @@ gentbl(
 cc_test(
     name = "option_tests",
     size = "small",
-    srcs = glob(["Option/*.cpp"]),
+    srcs = glob(
+        ["Option/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         ":option_tests_gen",
         "//llvm:Option",
@@ -429,7 +471,10 @@ cc_test(
 cc_test(
     name = "remarks_tests",
     size = "small",
-    srcs = glob(["Remarks/*.cpp"]),
+    srcs = glob(
+        ["Remarks/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:BitReader",
         "//llvm:Remarks",
@@ -443,7 +488,10 @@ cc_test(
 cc_test(
     name = "profile_data_tests",
     size = "small",
-    srcs = glob(["ProfileData/*.cpp"]),
+    srcs = glob(
+        ["ProfileData/*.cpp"],
+        allow_empty = False,
+    ),
     deps = [
         "//llvm:Core",
         "//llvm:Coverage",
@@ -525,7 +573,10 @@ cc_test(
 cc_test(
     name = "target_aarch64_tests",
     size = "small",
-    srcs = glob(["Target/AArch64/*.cpp"]),
+    srcs = glob(
+        ["Target/AArch64/*.cpp"],
+        allow_empty = False,
+    ),
     copts = [
         "$(STACK_FRAME_UNLIMITED)",
     ],


### PR DESCRIPTION
Includes fixing one glob that was empty due to a typo. We don't want
silent do-nothing tests. There's also
`--incompatible_disallow_empty_glob`, but on balance I think it's better
to continue allowing empty globs in non-test rules as we have future
proofing there against source changes and this config is for source code
that gets updated without updating the build files.

See https://github.com/google/llvm-bazel/pull/120
