### PR TITLE
Adopt td_library

### DIFF
--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -5,7 +5,7 @@
 # Description:
 #   The MLIR "Multi-Level Intermediate Representation" Compiler Infrastructure
 
-load(":tblgen.bzl", "gentbl")
+load(":tblgen.bzl", "gentbl", "td_library")
 load(":linalggen.bzl", "genlinalg")
 
 package(
@@ -45,7 +45,7 @@ exports_files([
         ],
         tblgen = ":mlir-tblgen",
         td_file = "include/mlir/IR/" + name + ".td",
-        td_srcs = [":OpBaseTdFiles"],
+        deps = [":OpBaseTdFiles"],
     )
     for name in [
         "OpAsmInterface",
@@ -53,6 +53,22 @@ exports_files([
         "SymbolInterfaces",
     ]
 ]
+
+td_library(
+    name = "BuiltinDialectTdFiles",
+    srcs = [
+        "include/mlir/IR/BuiltinDialect.td",
+        "include/mlir/IR/BuiltinOps.td",
+        "include/mlir/IR/BuiltinTypes.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CallInterfacesTdFiles",
+        ":CastInterfacesTdFiles",
+        ":OpBaseTdFiles",
+        ":SideEffectInterfacesTdFiles",
+    ],
+)
 
 gentbl(
     name = "BuiltinDialectIncGen",
@@ -65,7 +81,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/IR/BuiltinDialect.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":BuiltinDialectTdFiles"],
 )
 
 gentbl(
@@ -83,15 +99,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/IR/BuiltinOps.td",
-    td_srcs = [
-        "include/mlir/IR/BuiltinOps.td",
-        "include/mlir/IR/BuiltinDialect.td",
-        "include/mlir/Interfaces/CallInterfaces.td",
-        "include/mlir/Interfaces/CastInterfaces.td",
-        "include/mlir/IR/SymbolInterfaces.td",
-        ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
-    ],
+    deps = [":BuiltinDialectTdFiles"],
 )
 
 gentbl(
@@ -109,11 +117,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/IR/BuiltinTypes.td",
-    td_srcs = [
-        "include/mlir/IR/BuiltinTypes.td",
-        "include/mlir/IR/BuiltinDialect.td",
-        ":OpBaseTdFiles",
-    ],
+    deps = [":BuiltinDialectTdFiles"],
 )
 
 cc_library(
@@ -304,50 +308,116 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "OpBaseTdFiles",
     srcs = [
-        "include/mlir/Dialect/StandardOps/IR/StandardOpsBase.td",
+        "include/mlir/IR/OpAsmInterface.td",
         "include/mlir/IR/OpBase.td",
+        "include/mlir/IR/SymbolInterfaces.td",
     ],
+    includes = ["include"],
 )
 
-filegroup(
-    name = "SideEffectBaseTdFiles",
-    srcs = ["include/mlir/Interfaces/SideEffectInterfaceBase.td"],
+td_library(
+    name = "CallInterfacesTdFiles",
+    srcs = ["include/mlir/Interfaces/CallInterfaces.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
 )
 
-filegroup(
-    name = "SideEffectTdFiles",
+td_library(
+    name = "CastInterfacesTdFiles",
+    srcs = ["include/mlir/Interfaces/CastInterfaces.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "ControlFlowInterfacesTdFiles",
+    srcs = ["include/mlir/Interfaces/ControlFlowInterfaces.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "CopyOpInterfaceTdFiles",
+    srcs = ["include/mlir/Interfaces/CopyOpInterface.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "DerivedAttributeOpInterfaceTdFiles",
+    srcs = ["include/mlir/Interfaces/DerivedAttributeOpInterface.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "InferTypeOpInterfaceTdFiles",
+    srcs = ["include/mlir/Interfaces/InferTypeOpInterface.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "LoopLikeInterfaceTdFiles",
+    srcs = ["include/mlir/Interfaces/LoopLikeInterface.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "SideEffectInterfacesTdFiles",
     srcs = [
+        "include/mlir/Interfaces/SideEffectInterfaceBase.td",
         "include/mlir/Interfaces/SideEffectInterfaces.td",
-        ":SideEffectBaseTdFiles",
     ],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
 )
 
-filegroup(
+alias(
+    name = "SideEffectTdFiles",
+    actual = ":SideEffectInterfacesTdFiles",
+)
+
+td_library(
     name = "VectorInterfacesTdFiles",
     srcs = ["include/mlir/Interfaces/VectorInterfaces.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
+)
+
+td_library(
+    name = "ViewLikeInterfaceTdFiles",
+    srcs = ["include/mlir/Interfaces/ViewLikeInterface.td"],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # Affine dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "PassBaseTdFiles",
     srcs = ["include/mlir/Pass/PassBase.td"],
+    includes = ["include"],
 )
 
-filegroup(
+td_library(
     name = "AffineOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.td",
         "include/mlir/Dialect/Affine/IR/AffineOps.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-        "include/mlir/Interfaces/LoopLikeInterface.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":LoopLikeInterfaceTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
+        ":StdOpsTdFiles",
     ],
 )
 
@@ -370,7 +440,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Affine/IR/AffineOps.td",
-    td_srcs = [":AffineOpsTdFiles"],
+    deps = [":AffineOpsTdFiles"],
 )
 
 gentbl(
@@ -388,22 +458,25 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.td",
-    td_srcs = [":AffineOpsTdFiles"],
+    deps = [":AffineOpsTdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # Async dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "AsyncOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Async/IR/AsyncDialect.td",
         "include/mlir/Dialect/Async/IR/AsyncOps.td",
         "include/mlir/Dialect/Async/IR/AsyncTypes.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":ControlFlowInterfacesTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -434,7 +507,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Async/IR/AsyncOps.td",
-    td_srcs = [":AsyncOpsTdFiles"],
+    deps = [":AsyncOpsTdFiles"],
 )
 
 gentbl(
@@ -448,21 +521,18 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Async/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # ArmNeon dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "ArmNeonTdFiles",
-    srcs = [
-        "include/mlir/Dialect/ArmNeon/ArmNeon.td",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/IR/OpBase.td",
-        ":SideEffectTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/ArmNeon/ArmNeon.td"],
+    includes = ["include"],
+    deps = [":SideEffectInterfacesTdFiles"],
 )
 
 gentbl(
@@ -488,7 +558,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/ArmNeon/ArmNeon.td",
-    td_srcs = [":ArmNeonTdFiles"],
+    deps = [":ArmNeonTdFiles"],
 )
 
 cc_library(
@@ -522,7 +592,6 @@ cc_library(
         ":IR",
         ":LLVMArmNeon",
         ":LLVMDialect",
-        ":MathDialect",
         ":Pass",
         ":StandardOps",
         ":StandardToLLVM",
@@ -534,12 +603,11 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "LLVMArmNeonTdFiles",
-    srcs = [
-        "include/mlir/Dialect/LLVMIR/LLVMArmNeon.td",
-        ":LLVMOpsTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/LLVMIR/LLVMArmNeon.td"],
+    includes = ["include"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 gentbl(
@@ -565,7 +633,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMArmNeon.td",
-    td_srcs = [":LLVMArmNeonTdFiles"],
+    deps = [":LLVMArmNeonTdFiles"],
 )
 
 cc_library(
@@ -593,21 +661,18 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMArmNeon.td",
-    td_srcs = [":LLVMArmNeonTdFiles"],
+    deps = [":LLVMArmNeonTdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # ArmSVE dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "ArmSVETdFiles",
-    srcs = [
-        "include/mlir/Dialect/ArmSVE/ArmSVE.td",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/IR/OpBase.td",
-        ":SideEffectTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/ArmSVE/ArmSVE.td"],
+    includes = ["include"],
+    deps = [":SideEffectInterfacesTdFiles"],
 )
 
 gentbl(
@@ -637,7 +702,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/ArmSVE/ArmSVE.td",
-    td_srcs = [":ArmSVETdFiles"],
+    deps = [":ArmSVETdFiles"],
 )
 
 cc_library(
@@ -682,12 +747,11 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "LLVMArmSVETdFiles",
-    srcs = [
-        "include/mlir/Dialect/LLVMIR/LLVMArmSVE.td",
-        ":LLVMOpsTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/LLVMIR/LLVMArmSVE.td"],
+    includes = ["include"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 gentbl(
@@ -713,7 +777,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMArmSVE.td",
-    td_srcs = [":LLVMArmSVETdFiles"],
+    deps = [":LLVMArmSVETdFiles"],
 )
 
 cc_library(
@@ -741,21 +805,18 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMArmSVE.td",
-    td_srcs = [":LLVMArmSVETdFiles"],
+    deps = [":LLVMArmSVETdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # AVX512 dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "AVX512TdFiles",
-    srcs = [
-        "include/mlir/Dialect/AVX512/AVX512.td",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/IR/OpBase.td",
-        ":SideEffectTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/AVX512/AVX512.td"],
+    includes = ["include"],
+    deps = [":SideEffectInterfacesTdFiles"],
 )
 
 gentbl(
@@ -781,7 +842,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/AVX512/AVX512.td",
-    td_srcs = [":AVX512TdFiles"],
+    deps = [":AVX512TdFiles"],
 )
 
 cc_library(
@@ -823,12 +884,11 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "LLVMAVX512TdFiles",
-    srcs = [
-        "include/mlir/Dialect/LLVMIR/LLVMAVX512.td",
-        ":LLVMOpsTdFiles",
-    ],
+    srcs = ["include/mlir/Dialect/LLVMIR/LLVMAVX512.td"],
+    includes = ["include"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 gentbl(
@@ -854,7 +914,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMAVX512.td",
-    td_srcs = [":LLVMAVX512TdFiles"],
+    deps = [":LLVMAVX512TdFiles"],
 )
 
 cc_library(
@@ -882,21 +942,21 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMAVX512.td",
-    td_srcs = [":LLVMAVX512TdFiles"],
+    deps = [":LLVMAVX512TdFiles"],
 )
 
 ##---------------------------------------------------------------------------##
 # SCF dialect.
 ##---------------------------------------------------------------------------##
 
-filegroup(
+td_library(
     name = "SCFTdFiles",
-    srcs = [
-        "include/mlir/Dialect/SCF/SCFOps.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-        "include/mlir/Interfaces/LoopLikeInterface.td",
-        ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+    srcs = ["include/mlir/Dialect/SCF/SCFOps.td"],
+    includes = ["include"],
+    deps = [
+        ":ControlFlowInterfacesTdFiles",
+        ":LoopLikeInterfaceTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -919,7 +979,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SCF/SCFOps.td",
-    td_srcs = [":SCFTdFiles"],
+    deps = [":SCFTdFiles"],
 )
 
 gentbl(
@@ -933,7 +993,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SCF/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -956,19 +1016,21 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "StdOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/StandardOps/IR/Ops.td",
-        "include/mlir/IR/OpAsmInterface.td",
-        "include/mlir/IR/SymbolInterfaces.td",
-        "include/mlir/Interfaces/CallInterfaces.td",
-        "include/mlir/Interfaces/CastInterfaces.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-        "include/mlir/Interfaces/ViewLikeInterface.td",
+        "include/mlir/Dialect/StandardOps/IR/StandardOpsBase.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CallInterfacesTdFiles",
+        ":CastInterfacesTdFiles",
+        ":ControlFlowInterfacesTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
         ":VectorInterfacesTdFiles",
+        ":ViewLikeInterfaceTdFiles",
     ],
 )
 
@@ -999,7 +1061,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/StandardOps/IR/Ops.td",
-    td_srcs = [":StdOpsTdFiles"],
+    deps = [":StdOpsTdFiles"],
 )
 
 cc_library(
@@ -1138,7 +1200,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Affine/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1184,7 +1246,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Conversion/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1385,13 +1447,17 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "ShapeOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Shape/IR/ShapeBase.td",
         "include/mlir/Dialect/Shape/IR/ShapeOps.td",
-        "include/mlir/Interfaces/InferTypeOpInterface.td",
-        ":StdOpsTdFiles",
+    ],
+    includes = ["include"],
+    deps = [
+        ":ControlFlowInterfacesTdFiles",
+        ":InferTypeOpInterfaceTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -1414,11 +1480,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Shape/IR/ShapeOps.td",
-    td_srcs = [
-        ":StdOpsTdFiles",
-        "include/mlir/Dialect/Shape/IR/ShapeBase.td",
-        "include/mlir/Interfaces/InferTypeOpInterface.td",
-    ],
+    deps = [":ShapeOpsTdFiles"],
 )
 
 gentbl(
@@ -1432,12 +1494,10 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Dialect/Shape/IR/ShapeCanonicalization.td",
-    td_srcs = [
+    deps = [
+        ":ShapeOpsTdFiles",
         ":StdOpsTdFiles",
         ":TensorOpsTdFiles",
-        "include/mlir/Dialect/Shape/IR/ShapeBase.td",
-        "include/mlir/Dialect/Shape/IR/ShapeOps.td",
-        "include/mlir/Interfaces/InferTypeOpInterface.td",
     ],
 )
 
@@ -1474,7 +1534,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Conversion/ShapeToStandard/ShapeToStandard.td",
-    td_srcs = [":ShapeOpsTdFiles"],
+    deps = [":ShapeOpsTdFiles"],
 )
 
 cc_library(
@@ -1509,7 +1569,7 @@ gentbl(
     )],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Shape/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1572,7 +1632,7 @@ gentbl(
     )],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/StandardOps/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1691,7 +1751,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.td",
-    td_srcs = [":LLVMOpsTdFiles"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 cc_library(
@@ -1751,7 +1811,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1770,15 +1830,17 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "GPUOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/GPU/GPUBase.td",
         "include/mlir/Dialect/GPU/GPUOps.td",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/IR/SymbolInterfaces.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":LLVMOpsTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -1805,10 +1867,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/GPU/ParallelLoopMapperAttr.td",
-    td_srcs = [
-        ":GPUOpsTdFiles",
-        ":AffineOpsTdFiles",
-    ],
+    deps = [":GPUOpsTdFiles"],
 )
 
 gentbl(
@@ -1830,7 +1889,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/GPU/GPUBase.td",
-    td_srcs = [":GPUOpsTdFiles"],
+    deps = [":GPUOpsTdFiles"],
 )
 
 gentbl(
@@ -1848,7 +1907,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/GPU/GPUOps.td",
-    td_srcs = [":GPUOpsTdFiles"],
+    deps = [":GPUOpsTdFiles"],
 )
 
 cc_library(
@@ -1886,7 +1945,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/GPU/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -1920,16 +1979,18 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "LLVMOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
         "include/mlir/Dialect/LLVMIR/LLVMOps.td",
         "include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.td",
-        "include/mlir/IR/SymbolInterfaces.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":ControlFlowInterfacesTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -1964,7 +2025,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Conversion/GPUToNVVM/GPUToNVVM.td",
-    td_srcs = [
+    deps = [
         ":GPUOpsTdFiles",
         ":NVVMOpsTdFiles",
     ],
@@ -2048,7 +2109,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Conversion/GPUToROCDL/GPUToROCDL.td",
-    td_srcs = [
+    deps = [
         ":GPUOpsTdFiles",
         ":ROCDLOpsTdFiles",
     ],
@@ -2142,7 +2203,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Conversion/GPUToSPIRV/GPUToSPIRV.td",
-    td_srcs = [
+    deps = [
         ":GPUOpsTdFiles",
         ":SPIRVOpsTdFiles",
     ],
@@ -2251,7 +2312,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMOps.td",
-    td_srcs = [":LLVMOpsTdFiles"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 gentbl(
@@ -2273,7 +2334,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/LLVMOps.td",
-    td_srcs = [":LLVMOpsTdFiles"],
+    deps = [":LLVMOpsTdFiles"],
 )
 
 cc_library(
@@ -2294,13 +2355,14 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "NVVMOpsTdFiles",
-    srcs = [
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/Dialect/LLVMIR/NVVMOps.td",
+    srcs = ["include/mlir/Dialect/LLVMIR/NVVMOps.td"],
+    includes = ["include"],
+    deps = [
+        ":LLVMOpsTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -2323,7 +2385,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/NVVMOps.td",
-    td_srcs = [":NVVMOpsTdFiles"],
+    deps = [":NVVMOpsTdFiles"],
 )
 
 gentbl(
@@ -2337,7 +2399,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/NVVMOps.td",
-    td_srcs = [":NVVMOpsTdFiles"],
+    deps = [":NVVMOpsTdFiles"],
 )
 
 cc_library(
@@ -2358,13 +2420,14 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "ROCDLOpsTdFiles",
-    srcs = [
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
+    srcs = ["include/mlir/Dialect/LLVMIR/ROCDLOps.td"],
+    includes = ["include"],
+    deps = [
+        ":LLVMOpsTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -2387,7 +2450,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
-    td_srcs = [":ROCDLOpsTdFiles"],
+    deps = [":ROCDLOpsTdFiles"],
 )
 
 gentbl(
@@ -2401,7 +2464,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
-    td_srcs = [":ROCDLOpsTdFiles"],
+    deps = [":ROCDLOpsTdFiles"],
 )
 
 cc_library(
@@ -2425,15 +2488,16 @@ cc_library(
     ],
 )
 
-filegroup(
-    name = "PDLOpsTdFiles",
+td_library(
+    name = "PDLDialectTdFiles",
     srcs = [
         "include/mlir/Dialect/PDL/IR/PDLDialect.td",
         "include/mlir/Dialect/PDL/IR/PDLOps.td",
         "include/mlir/Dialect/PDL/IR/PDLTypes.td",
-        "include/mlir/IR/SymbolInterfaces.td",
+    ],
+    deps = [
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -2456,7 +2520,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/PDL/IR/PDLOps.td",
-    td_srcs = [":PDLOpsTdFiles"],
+    deps = [":PDLDialectTdFiles"],
 )
 
 gentbl(
@@ -2474,11 +2538,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/PDL/IR/PDLTypes.td",
-    td_srcs = [
-        ":OpBaseTdFiles",
-        "include/mlir/Dialect/PDL/IR/PDLDialect.td",
-        "include/mlir/Dialect/PDL/IR/PDLTypes.td",
-    ],
+    deps = [":PDLDialectTdFiles"],
 )
 
 cc_library(
@@ -2502,14 +2562,14 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "PDLInterpOpsTdFiles",
-    srcs = [
-        "include/mlir/Dialect/PDL/IR/PDLDialect.td",
-        "include/mlir/Dialect/PDL/IR/PDLTypes.td",
-        "include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td",
+    srcs = ["include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td"],
+    includes = ["include"],
+    deps = [
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":PDLDialectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -2532,19 +2592,19 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td",
-    td_srcs = [":PDLInterpOpsTdFiles"],
+    deps = [":PDLInterpOpsTdFiles"],
 )
 
-# TODO(gcmn): Update SPIRV dependencies so that they map better to cmake files.
-filegroup(
+td_library(
     name = "SPIRVOpsTdFiles",
-    srcs = [
-        "include/mlir/IR/SymbolInterfaces.td",
-        "include/mlir/Interfaces/CallInterfaces.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-        ":SideEffectTdFiles",
+    srcs = glob(["include/mlir/Dialect/SPIRV/IR/*.td"]),
+    includes = ["include"],
+    deps = [
+        ":CallInterfacesTdFiles",
+        ":ControlFlowInterfacesTdFiles",
         ":OpBaseTdFiles",
-    ] + glob(["include/mlir/Dialect/SPIRV/IR/*.td"]),
+        ":SideEffectInterfacesTdFiles",
+    ],
 )
 
 gentbl(
@@ -2590,7 +2650,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/IR/SPIRVOps.td",
-    td_srcs = [":SPIRVOpsTdFiles"],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 gentbl(
@@ -2604,10 +2664,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "lib/Dialect/SPIRV/IR/SPIRVCanonicalization.td",
-    td_srcs = [
-        ":SPIRVOpsTdFiles",
-        "lib/Dialect/SPIRV/IR/SPIRVCanonicalization.td",
-    ],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 gentbl(
@@ -2629,7 +2686,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/IR/SPIRVOps.td",
-    td_srcs = [":SPIRVOpsTdFiles"],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 gentbl(
@@ -2646,10 +2703,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/IR/TargetAndABI.td",
-    td_srcs = [
-        ":SPIRVOpsTdFiles",
-        ":StdOpsTdFiles",
-    ],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 gentbl(
@@ -2663,10 +2717,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/IR/SPIRVBase.td",
-    td_srcs = [
-        ":SPIRVOpsTdFiles",
-        ":SPIRVAvailabilityIncGen",
-    ],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 gentbl(
@@ -2680,7 +2731,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/IR/SPIRVOps.td",
-    td_srcs = [":SPIRVOpsTdFiles"],
+    deps = [":SPIRVOpsTdFiles"],
 )
 
 cc_library(
@@ -2723,7 +2774,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/SPIRV/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -2832,11 +2883,9 @@ cc_library(
         "lib/Target/SPIRV/Serialization/Serialization.cpp",
         "lib/Target/SPIRV/Serialization/SerializeOps.cpp",
         "lib/Target/SPIRV/Serialization/Serializer.cpp",
-    ],
-    hdrs = [
-        "include/mlir/Target/SPIRV/Serialization.h",
         "lib/Target/SPIRV/Serialization/Serializer.h",
     ],
+    hdrs = ["include/mlir/Target/SPIRV/Serialization.h"],
     includes = ["include"],
     deps = [
         ":IR",
@@ -2903,15 +2952,18 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "TensorOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Tensor/IR/TensorBase.td",
         "include/mlir/Dialect/Tensor/IR/TensorOps.td",
-        "include/mlir/Interfaces/CastInterfaces.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CastInterfacesTdFiles",
+        ":ControlFlowInterfacesTdFiles",
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -2926,7 +2978,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tensor/IR/TensorBase.td",
-    td_srcs = [":TensorOpsTdFiles"],
+    deps = [":TensorOpsTdFiles"],
 )
 
 gentbl(
@@ -2944,7 +2996,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tensor/IR/TensorOps.td",
-    td_srcs = [":TensorOpsTdFiles"],
+    deps = [":TensorOpsTdFiles"],
 )
 
 cc_library(
@@ -2980,7 +3032,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tensor/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -3070,7 +3122,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/DerivedAttributeOpInterface.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":DerivedAttributeOpInterfaceTdFiles"],
 )
 
 cc_library(
@@ -3101,7 +3153,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/LoopLikeInterface.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":LoopLikeInterfaceTdFiles"],
 )
 
 gentbl(
@@ -3119,7 +3171,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/VectorInterfaces.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":VectorInterfacesTdFiles"],
 )
 
 gentbl(
@@ -3137,7 +3189,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/ViewLikeInterface.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":ViewLikeInterfaceTdFiles"],
 )
 
 gentbl(
@@ -3155,7 +3207,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/CopyOpInterface.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":CopyOpInterfaceTdFiles"],
 )
 
 gentbl(
@@ -3177,7 +3229,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -3385,7 +3437,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/CallInterfaces.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":CallInterfacesTdFiles"],
 )
 
 cc_library(
@@ -3416,7 +3468,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/CastInterfaces.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":CastInterfacesTdFiles"],
 )
 
 cc_library(
@@ -3447,7 +3499,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/ControlFlowInterfaces.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":ControlFlowInterfacesTdFiles"],
 )
 
 cc_library(
@@ -3478,7 +3530,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/InferTypeOpInterface.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":InferTypeOpInterfaceTdFiles"],
 )
 
 cc_library(
@@ -3509,10 +3561,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Interfaces/SideEffectInterfaces.td",
-    td_srcs = [
-        ":OpBaseTdFiles",
-        ":SideEffectBaseTdFiles",
-    ],
+    deps = [":SideEffectInterfacesTdFiles"],
 )
 
 cc_library(
@@ -4258,8 +4307,10 @@ cc_binary(
 
 ## OpenACC dialect
 
+# TODO(gcmn): This is sticking td files in a cc_library
 gentbl(
     name = "AccCommonGen",
+    includes = ["/llvm/include"],
     strip_include_prefix = "include",
     tbl_outs = [
         (
@@ -4269,8 +4320,17 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "//llvm:include/llvm/Frontend/OpenACC/ACC.td",
-    td_includes = ["external/llvm-project/llvm/include"],
-    td_srcs = ["//llvm:acc_td_files"],
+    deps = ["//llvm:acc_td_files"],
+)
+
+td_library(
+    name = "OpenAccOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/OpenACC/AccCommon.td",
+        "include/mlir/Dialect/OpenACC/OpenACCOps.td",
+    ],
+    includes = ["include"],
+    deps = [":OpBaseTdFiles"],
 )
 
 gentbl(
@@ -4304,11 +4364,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/OpenACC/OpenACCOps.td",
-    td_srcs = [
-        ":OpBaseTdFiles",
-        ":OmpCommonTdGen",
-        "include/mlir/Dialect/OpenACC/AccCommon.td",
-    ],
+    deps = [":OpenAccOpsTdFiles"],
 )
 
 cc_library(
@@ -4332,8 +4388,11 @@ cc_library(
 )
 
 ## OpenMP dialect
+
+# TODO(gcmn): This is sticking td files in a cc_library
 gentbl(
     name = "OmpCommonTdGen",
+    includes = ["/llvm/include"],
     strip_include_prefix = "include",
     tbl_outs = [
         (
@@ -4343,9 +4402,20 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "//llvm:include/llvm/Frontend/OpenMP/OMP.td",
-    td_includes = ["external/llvm-project/llvm/include"],
-    td_srcs = [
+    deps = [
+        ":OpBaseTdFiles",
         "//llvm:omp_td_files",
+    ],
+)
+
+td_library(
+    name = "OpenMPOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/OpenMP/OmpCommon.td",
+        "include/mlir/Dialect/OpenMP/OpenMPOps.td",
+    ],
+    deps = [
+        ":LLVMOpsTdFiles",
         ":OpBaseTdFiles",
     ],
 )
@@ -4381,14 +4451,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/OpenMP/OpenMPOps.td",
-    td_srcs = [
-        ":OpBaseTdFiles",
-        ":OmpCommonTdGen",
-        ":SideEffectTdFiles",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/Dialect/OpenMP/OmpCommon.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-    ],
+    deps = [":OpenMPOpsTdFiles"],
 )
 
 cc_library(
@@ -4438,14 +4501,16 @@ cc_library(
     ],
 )
 
-## QuantOps dialect
-filegroup(
+td_library(
     name = "QuantizationOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Quant/QuantOps.td",
         "include/mlir/Dialect/Quant/QuantOpsBase.td",
+    ],
+    includes = ["include"],
+    deps = [
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -4472,7 +4537,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Quant/QuantOps.td",
-    td_srcs = [":QuantizationOpsTdFiles"],
+    deps = [":QuantizationOpsTdFiles"],
 )
 
 gentbl(
@@ -4486,7 +4551,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Quant/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -4524,15 +4589,19 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "LinalgOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Linalg/IR/LinalgBase.td",
         "include/mlir/Dialect/Linalg/IR/LinalgOps.td",
-        "include/mlir/Interfaces/CopyOpInterface.td",
-        "include/mlir/Interfaces/ViewLikeInterface.td",
-        ":AffineOpsTdFiles",
+    ],
+    includes = ["include"],
+    deps = [
+        ":ControlFlowInterfacesTdFiles",
+        ":LoopLikeInterfaceTdFiles",
         ":OpBaseTdFiles",
+        ":SideEffectInterfacesTdFiles",
+        ":ViewLikeInterfaceTdFiles",
     ],
 )
 
@@ -4555,7 +4624,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/IR/LinalgOps.td",
-    td_srcs = [":LinalgOpsTdFiles"],
+    deps = [":LinalgOpsTdFiles"],
 )
 
 genlinalg(
@@ -4590,18 +4659,20 @@ genlinalg(
     linalggen = ":mlir-linalg-ods-yaml-gen",
 )
 
-filegroup(
+td_library(
     name = "LinalgStructuredOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td",
         "include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.tcgen.td",
         "include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yamlgen.td",
         "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td",
-        "include/mlir/Interfaces/CopyOpInterface.td",
-        "include/mlir/Interfaces/ViewLikeInterface.td",
-        ":AffineOpsTdFiles",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CopyOpInterfaceTdFiles",
         ":LinalgOpsTdFiles",
         ":OpBaseTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -4620,20 +4691,16 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td",
-    td_srcs = [
-        ":LinalgStructuredOpsTdFiles",
-        "include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.tcgen.td",
-        "include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yamlgen.td",
-    ],
+    deps = [":LinalgStructuredOpsTdFiles"],
 )
 
-filegroup(
+td_library(
     name = "LinalgSparseOpsTdFiles",
-    srcs = [
-        "include/mlir/Dialect/Linalg/IR/LinalgBase.td",
-        "include/mlir/Dialect/Linalg/IR/LinalgSparseOps.td",
-        ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+    srcs = ["include/mlir/Dialect/Linalg/IR/LinalgSparseOps.td"],
+    includes = ["include"],
+    deps = [
+        ":LinalgOpsTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -4652,7 +4719,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/IR/LinalgSparseOps.td",
-    td_srcs = [":LinalgSparseOpsTdFiles"],
+    deps = [":LinalgSparseOpsTdFiles"],
 )
 
 gentbl(
@@ -4670,13 +4737,14 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td",
-    td_srcs = [":LinalgStructuredOpsTdFiles"],
+    deps = [":LinalgStructuredOpsTdFiles"],
 )
 
-filegroup(
+td_library(
     name = "LinalgDocTdFiles",
-    srcs = [
-        "include/mlir/Dialect/Linalg/IR/LinalgDoc.td",
+    srcs = ["include/mlir/Dialect/Linalg/IR/LinalgDoc.td"],
+    includes = ["include"],
+    deps = [
         ":LinalgOpsTdFiles",
         ":LinalgStructuredOpsTdFiles",
     ],
@@ -4693,7 +4761,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/IR/LinalgDoc.td",
-    td_srcs = [":LinalgDocTdFiles"],
+    deps = [":LinalgDocTdFiles"],
 )
 
 cc_library(
@@ -4824,7 +4892,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Linalg/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -4881,14 +4949,15 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "VectorOpsTdFiles",
-    srcs = [
-        "include/mlir/Dialect/Vector/VectorOps.td",
-        "include/mlir/Interfaces/ViewLikeInterface.td",
-        ":AffineOpsTdFiles",
+    srcs = ["include/mlir/Dialect/Vector/VectorOps.td"],
+    includes = ["include"],
+    deps = [
         ":OpBaseTdFiles",
+        ":SideEffectInterfacesTdFiles",
         ":VectorInterfacesTdFiles",
+        ":ViewLikeInterfaceTdFiles",
     ],
 )
 
@@ -4923,7 +4992,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Vector/VectorOps.td",
-    td_srcs = [":VectorOpsTdFiles"],
+    deps = [":VectorOpsTdFiles"],
 )
 
 cc_library(
@@ -4991,13 +5060,13 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "TosaDialectTdFiles",
-    srcs = glob(["include/mlir/Dialect/Tosa/IR/*.td"]) + [
-        "include/mlir/Interfaces/LoopLikeInterface.td",
+    srcs = glob(["include/mlir/Dialect/Tosa/IR/*.td"]),
+    deps = [
+        ":LoopLikeInterfaceTdFiles",
         ":OpBaseTdFiles",
-        ":QuantizationOpsTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -5032,14 +5101,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tosa/IR/TosaOps.td",
-    td_srcs = [
-        ":OpBaseTdFiles",
-        "include/mlir/Dialect/Tosa/IR/TosaOpBase.td",
-        "include/mlir/Dialect/Tosa/IR/TosaInterfaces.td",
-        "include/mlir/Dialect/Tosa/IR/TosaTypesBase.td",
-        ":SideEffectTdFiles",
-        "include/mlir/Interfaces/LoopLikeInterface.td",
-    ],
+    deps = [":TosaDialectTdFiles"],
 )
 
 gentbl(
@@ -5057,7 +5119,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tosa/IR/TosaInterfaces.td",
-    td_srcs = [":OpBaseTdFiles"],
+    deps = [":TosaDialectTdFiles"],
 )
 
 gentbl(
@@ -5071,7 +5133,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Tosa/Transforms/Passes.td",
-    td_srcs = [":PassBaseTdFiles"],
+    deps = [":PassBaseTdFiles"],
 )
 
 cc_library(
@@ -5176,13 +5238,16 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "ComplexOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Complex/IR/ComplexBase.td",
         "include/mlir/Dialect/Complex/IR/ComplexOps.td",
+    ],
+    includes = ["include"],
+    deps = [
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
         ":VectorInterfacesTdFiles",
     ],
 )
@@ -5198,7 +5263,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Complex/IR/ComplexBase.td",
-    td_srcs = [":ComplexOpsTdFiles"],
+    deps = [":ComplexOpsTdFiles"],
 )
 
 gentbl(
@@ -5216,7 +5281,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Complex/IR/ComplexOps.td",
-    td_srcs = [":ComplexOpsTdFiles"],
+    deps = [":ComplexOpsTdFiles"],
 )
 
 cc_library(
@@ -5293,13 +5358,16 @@ exports_files(
     visibility = [":friends"],
 )
 
-filegroup(
+td_library(
     name = "MathOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Math/IR/MathBase.td",
         "include/mlir/Dialect/Math/IR/MathOps.td",
+    ],
+    includes = ["include"],
+    deps = [
         ":OpBaseTdFiles",
-        ":SideEffectTdFiles",
+        ":SideEffectInterfacesTdFiles",
         ":VectorInterfacesTdFiles",
     ],
 )
@@ -5315,9 +5383,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Math/IR/MathBase.td",
-    td_srcs = [
-        ":MathOpsTdFiles",
-    ],
+    deps = [":MathOpsTdFiles"],
 )
 
 gentbl(
@@ -5335,9 +5401,7 @@ gentbl(
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/Math/IR/MathOps.td",
-    td_srcs = [
-        ":MathOpsTdFiles",
-    ],
+    deps = [":MathOpsTdFiles"],
 )
 
 cc_library(

--- a/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//mlir:tblgen.bzl", "gentbl")
+load("//mlir:tblgen.bzl", "gentbl", "td_library")
 
 package(
     default_visibility = [":test_friends"],
@@ -36,13 +36,11 @@ cc_library(
     ],
 )
 
-filegroup(
+td_library(
     name = "TestOpTdFiles",
     srcs = [
         "lib/Dialect/Test/TestInterfaces.td",
         "lib/Dialect/Test/TestOps.td",
-        "//mlir:OpBaseTdFiles",
-        "//mlir:SideEffectTdFiles",
         "//mlir:include/mlir/IR/OpAsmInterface.td",
         "//mlir:include/mlir/IR/RegionKindInterface.td",
         "//mlir:include/mlir/IR/SymbolInterfaces.td",
@@ -50,6 +48,10 @@ filegroup(
         "//mlir:include/mlir/Interfaces/ControlFlowInterfaces.td",
         "//mlir:include/mlir/Interfaces/CopyOpInterface.td",
         "//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
+    ],
+    deps = [
+        "//mlir:OpBaseTdFiles",
+        "//mlir:SideEffectTdFiles",
     ],
 )
 
@@ -92,10 +94,10 @@ gentbl(
     ],
     tblgen = "//mlir:mlir-tblgen",
     td_file = "lib/Dialect/Test/TestOps.td",
-    td_srcs = [
+    test = True,
+    deps = [
         ":TestOpTdFiles",
     ],
-    test = True,
 )
 
 gentbl(
@@ -121,11 +123,11 @@ gentbl(
     ],
     tblgen = "//mlir:mlir-tblgen",
     td_file = "lib/Dialect/Test/TestInterfaces.td",
-    td_srcs = [
-        "//mlir:OpBaseTdFiles",
-        "//mlir:SideEffectBaseTdFiles",
-    ],
     test = True,
+    deps = [
+        "//mlir:OpBaseTdFiles",
+        "//mlir:SideEffectInterfacesTdFiles",
+    ],
 )
 
 gentbl(
@@ -164,10 +166,10 @@ gentbl(
     ],
     tblgen = "//mlir:mlir-tblgen",
     td_file = "lib/Dialect/Test/TestTypeDefs.td",
-    td_srcs = [
+    test = True,
+    deps = [
         ":TestOpTdFiles",
     ],
-    test = True,
 )
 
 cc_library(


### PR DESCRIPTION
Following https://github.com/google/llvm-bazel/pull/156, this avoids
needing to list all transitive include dependencies and tracks include
directories.