### PR TITLE
Add support for mingw-gcc.

### DIFF
--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -73,6 +73,7 @@ build:generic_gcc --copt=-Werror --host_copt=-Werror
 ###############################################################################
 
 build:mingw_gcc --config=generic_gcc
+build:mingw_gcc --compiler=mingw-gcc
 
 # Other windows toolchains have these by default
 build:mingw_gcc --cxxopt=-DHAVE_UNISTD_H=1 --host_cxxopt=-DHAVE_UNISTD_H=1

--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -77,6 +77,18 @@ build:mingw_gcc --config=generic_gcc
 # Other windows toolchains have these by default
 build:mingw_gcc --cxxopt=-DHAVE_UNISTD_H=1 --host_cxxopt=-DHAVE_UNISTD_H=1
 
+# The following link options should go on the BUILD rules instead, but:
+# 1. It's very challenging to make select constraints work properly
+# 2. Trying to set them for windows in general will trigger msvc warnings for
+# unknown flags.
+
+# Needed by @llvm-project//llvm:llvm-tblgen, @llvm-project//clang:clang-tblgen, @llvm-project//clang:clang-scan-deps
+build:mingw_gcc --linkopt=-lole32 --host_linkopt=-lole32
+# Needed by @llvm-project//llvm:llvm-tblgen, @llvm-project//clang:clang-tblgen, @llvm-project//clang:clang-scan-deps
+build:mingw_gcc --linkopt=-luuid --host_linkopt=-luuid
+# Needed by @llvm-project//clang:clang-scan-deps
+build:mingw_gcc --linkopt=-lversion --host_linkopt=-lversion
+
 # Needed to avoid  "File too big" error. -Wa,-mbig-obj doesn't seem to fix it.
 build:mingw_gcc --cxxopt=-O2
 

--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -72,11 +72,10 @@ build:generic_gcc --copt=-Werror --host_copt=-Werror
 # Windows specific flags for building with GCC. Used on top of generic_gcc
 ###############################################################################
 
+build:mingw_gcc --config=generic_gcc
+
 # Other windows toolchains have these by default
 build:mingw_gcc --cxxopt=-DHAVE_UNISTD_H=1 --host_cxxopt=-DHAVE_UNISTD_H=1
-build:mingw_gcc --linkopt=-lole32 --host_linkopt=-lole32
-build:mingw_gcc --linkopt=-luuid --host_linkopt=-luuid
-build:mingw_gcc --linkopt=-lversion --host_linkopt=-lversion
 
 # Needed to avoid  "File too big" error. -Wa,-mbig-obj doesn't seem to fix it.
 build:mingw_gcc --cxxopt=-O2

--- a/llvm-bazel/.bazelrc
+++ b/llvm-bazel/.bazelrc
@@ -69,6 +69,23 @@ build:generic_gcc --copt=-Wno-misleading-indentation --host_copt=-Wno-misleading
 build:generic_gcc --copt=-Werror --host_copt=-Werror
 
 ###############################################################################
+# Windows specific flags for building with GCC. Used on top of generic_gcc
+###############################################################################
+
+# Other windows toolchains have these by default
+build:mingw_gcc --cxxopt=-DHAVE_UNISTD_H=1 --host_cxxopt=-DHAVE_UNISTD_H=1
+build:mingw_gcc --linkopt=-lole32 --host_linkopt=-lole32
+build:mingw_gcc --linkopt=-luuid --host_linkopt=-luuid
+build:mingw_gcc --linkopt=-lversion --host_linkopt=-lversion
+
+# Needed to avoid  "File too big" error. -Wa,-mbig-obj doesn't seem to fix it.
+build:mingw_gcc --cxxopt=-O2
+
+# external/llvm-project/clang/tools/libclang/CXCompilationDatabase.cpp:59 contains errors
+# eg: redeclared without dllimport attribute: previous dllimport ignored [-Werror=attributes]
+build:mingw_gcc --cxxopt=-Wno-attributes --host_cxxopt=-Wno-attributes
+
+###############################################################################
 # Windows specific flags for building with VC.
 ###############################################################################
 

--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -30,13 +30,7 @@ cc_binary(
         "$(STACK_FRAME_UNLIMITED)",
     ],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [
-            # These are only needed by mingw-gcc,
-            # but getting bazel's constraints to work
-            # is challenging.
-            "-lole32",
-            "-luuid",
-        ],
+        "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
             "-ldl",
         ],
@@ -2060,15 +2054,4 @@ cc_binary(
         ":tooling_dependency_scanning",
         "//llvm:Support",
     ],
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [
-            # These are only needed by mingw-gcc,
-            # but getting bazel's constraints to work
-            # is challenging.
-            "-lole32",
-            "-luuid",
-            "-lversion",
-        ],
-        "//conditions:default": [],
-    }),
 )

--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -30,7 +30,13 @@ cc_binary(
         "$(STACK_FRAME_UNLIMITED)",
     ],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:windows": [
+            # These are only needed by mingw-gcc,
+            # but getting bazel's constraints to work
+            # is challenging.
+            "-lole32",
+            "-luuid",
+        ],
         "//conditions:default": [
             "-ldl",
         ],
@@ -2054,4 +2060,15 @@ cc_binary(
         ":tooling_dependency_scanning",
         "//llvm:Support",
     ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [
+            # These are only needed by mingw-gcc,
+            # but getting bazel's constraints to work
+            # is challenging.
+            "-lole32",
+            "-luuid",
+            "-lversion",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/llvm-bazel/llvm-project-overlay/clang/BUILD
+++ b/llvm-bazel/llvm-project-overlay/clang/BUILD
@@ -29,7 +29,12 @@ cc_binary(
     copts = [
         "$(STACK_FRAME_UNLIMITED)",
     ],
-    linkopts = ["-ldl"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-ldl",
+        ],
+    }),
     stamp = 0,
     deps = [
         "//llvm:Support",

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -486,16 +486,6 @@ cc_binary(
     deps = [
         ":tblgen",
     ],
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [
-            # These are only needed by mingw-gcc,
-            # but getting bazel's constraints to work
-            # is challenging.
-            "-lole32",
-            "-luuid",
-        ],
-        "//conditions:default": [],
-    }),
 )
 
 gentbl(

--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -486,6 +486,16 @@ cc_binary(
     deps = [
         ":tblgen",
     ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [
+            # These are only needed by mingw-gcc,
+            # but getting bazel's constraints to work
+            # is challenging.
+            "-lole32",
+            "-luuid",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 gentbl(


### PR DESCRIPTION
Note that this is also blocked by #130.
That error also affects @llvm-project/llvm:llvm-mca-headers.

This doesn't build _everything_. Particularly, the last
error I got through was on setenv not being declared in
llvm/llvm/unittests/Support/ThreadPool.cpp. I imagine the issue might be
related to some of the other headers that we're including for linux and
posix only.

Note that I can't get mingw-gcc to work with RBE. GCC on windows
will try to canonize paths that look shorter than the original ones:
https://github.com/gcc-mirror/gcc/blob/16e2427f50c208dfe07d07f18009969502c25dc8/libcpp/files.c#L405.

That means that relative includes (eg "lib/Support/../../", eg [1]) are made
absolute, which end up showing an absolute path on the `.d` files.

[1] https://github.com/llvm/llvm-project/blob/main/llvm/lib/Support/AArch64TargetParser.cpp#L58