### PR TITLE
Move linkopts to llvm:Support

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD
@@ -215,6 +215,7 @@ cc_library(
         "//conditions:default": [
             "-pthread",
             "-ldl",
+            "-lm",
         ],
     }),
     textual_hdrs = glob([

--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -209,13 +209,6 @@ cc_library(
         "include/mlir/Pass/*.h",
     ]),
     includes = ["include"],
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": [
-            "-lm",
-            "-lpthread",
-        ],
-    }),
     deps = [
         ":IR",
         ":Support",
@@ -4238,10 +4231,6 @@ cc_library(
 cc_binary(
     name = "mlir-cpu-runner",
     srcs = ["tools/mlir-cpu-runner/mlir-cpu-runner.cpp"],
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": ["-ldl"],
-    }),
     deps = [
         ":AllToLLVMIRTranslations",
         ":ExecutionEngineUtils",
@@ -4373,13 +4362,6 @@ cc_binary(
         "tools/mlir-tblgen/*.h",
         "tools/mlir-tblgen/*.cpp",
     ]),
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": [
-            "-lm",
-            "-lpthread",
-        ],
-    }),
     deps = [
         ":MlirTableGenMain",
         ":Support",
@@ -4395,13 +4377,6 @@ cc_binary(
     srcs = [
         "tools/mlir-linalg-ods-gen/mlir-linalg-ods-gen.cpp",
     ],
-    linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": [
-            "-lm",
-            "-lpthread",
-        ],
-    }),
     deps = [
         ":IR",
         ":Support",


### PR DESCRIPTION
`-lm` is needed by Support itself. Adding this on every possible leaf
binary seems a bit silly. There will be some weirdness by nature of
this being a transitive thing (line `includes`) that means we might
have some things happen to work because they dep on Support even though
there are other libraries that really should have those options as well
and don't have them, but I'm not sure how to avoid that. Luckily the
linker error gives you the name of the object file, so I think adding
the option on the appropriate library if/when that comes up shouldn't
be too bad.

Fixes #188