### PR TITLE
Adjust the hardcoded tablegen include paths to match the package's name

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
@@ -35,6 +35,9 @@ def gentbl(
       tblgen_args: Extra arguments string to pass to the tblgen binary.
       **kwargs: Keyword arguments to pass to subsidiary cc_library() rule.
     """
+    llvm_project_workspace = Label("//:...", relative_to_caller_repository = False)
+    llvm_project_execroot_path = llvm_project_workspace.workspace_root
+
     if td_file not in td_srcs:
         td_srcs += [td_file]
     for (opts, out) in tbl_outs:
@@ -45,11 +48,13 @@ def gentbl(
             outs = [out],
             tools = [tblgen],
             message = "Generating code from table: %s" % td_file,
-            cmd = (("$(location %s) -I external/llvm-project/llvm/include " +
-                    "-I external/llvm-project/clang/include " +
+            cmd = (("$(location %s) -I %s/llvm/include " +
+                    "-I %s/clang/include " +
                     "-I $$(dirname $(location %s)) " +
                     "%s $(location %s) %s -o $@") % (
                 tblgen,
+                llvm_project_execroot_path,
+                llvm_project_execroot_path,
                 td_file,
                 opts,
                 td_file,

--- a/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/llvm/tblgen.bzl
@@ -35,8 +35,7 @@ def gentbl(
       tblgen_args: Extra arguments string to pass to the tblgen binary.
       **kwargs: Keyword arguments to pass to subsidiary cc_library() rule.
     """
-    llvm_project_workspace = Label("//:...", relative_to_caller_repository = False)
-    llvm_project_execroot_path = llvm_project_workspace.workspace_root
+    llvm_project_execroot_path = Label("//llvm:tblgen.bzl", relative_to_caller_repository = False).workspace_root
 
     if td_file not in td_srcs:
         td_srcs += [td_file]

--- a/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -324,8 +324,7 @@ def gentbl(
       test: whether to create a shell test that invokes the tool too.
       **kwargs: Extra keyword arguments to pass to all generated rules.
     """
-    llvm_project_workspace = Label("//:...", relative_to_caller_repository = False)
-    llvm_project_execroot_path = llvm_project_workspace.workspace_root
+    llvm_project_execroot_path = Label("//llvm:tblgen.bzl", relative_to_caller_repository = False).workspace_root
 
     for (opts_string, out) in tbl_outs:
         # TODO(gcmn): The API of opts as single string is preserved for backward

--- a/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -324,6 +324,9 @@ def gentbl(
       test: whether to create a shell test that invokes the tool too.
       **kwargs: Extra keyword arguments to pass to all generated rules.
     """
+    llvm_project_workspace = Label("//:...", relative_to_caller_repository = False)
+    llvm_project_execroot_path = llvm_project_workspace.workspace_root
+
     for (opts_string, out) in tbl_outs:
         # TODO(gcmn): The API of opts as single string is preserved for backward
         # compatibility. Change to taking a sequence.
@@ -349,7 +352,7 @@ def gentbl(
             # TODO(gcmn): Update callers to td_library and explicit includes and
             # drop this hardcoded include.
             td_includes = td_includes + [
-                "external/llvm-project/mlir/include",
+                "%s/mlir/include" % llvm_project_execroot_path,
             ],
             out = out,
             **kwargs
@@ -369,7 +372,7 @@ def gentbl(
                 # TODO(gcmn): Update callers to td_library and explicit includes
                 # and drop this hardcoded include.
                 td_includes = td_includes + [
-                    "external/llvm-project/mlir/include",
+                    "%s/mlir/include" % llvm_project_execroot_path,
                 ],
                 **kwargs
             )

--- a/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -324,7 +324,7 @@ def gentbl(
       test: whether to create a shell test that invokes the tool too.
       **kwargs: Extra keyword arguments to pass to all generated rules.
     """
-    llvm_project_execroot_path = Label("//llvm:tblgen.bzl", relative_to_caller_repository = False).workspace_root
+    llvm_project_execroot_path = Label("//mlir:tblgen.bzl", relative_to_caller_repository = False).workspace_root
 
     for (opts_string, out) in tbl_outs:
         # TODO(gcmn): The API of opts as single string is preserved for backward


### PR DESCRIPTION
Right now, tablegen files that (transitively) depend on tablegen files within `mlir/include` fail to build if the package name passed to `llvm_configure` is something other than `llvm-project`.

<details> <summary>For example:</summary>

```tablegen
// test.td
include "mlir/IR/OpBase.td"

def Foo : Dialect {
  let name = "foo";
  let description = [{}];
  let cppNamespace = "foo";
}
```

```starlark
# BUILD
load("@llvm//mlir:tblgen.bzl", "gentbl")

gentbl(
    name = "test",
    tbl_outs = [
        ("-gen-op-decls", "test.h.inc"),
    ],
    tblgen = "@llvm//mlir:mlir-tblgen",
    td_file = "test.td",
    td_srcs = [
        "test.td",
        "@llvm//mlir:OpBaseTdFiles"
    ],
)
```
</details>

(A full workspace example is [attached](https://github.com/google/llvm-bazel/files/6416876/example.zip).)

---

This happens because the include path for `mlir/include` that's passed to tablegen is [hardcoded](https://github.com/google/llvm-bazel/blob/7d97961847d0576226a6055009da040b6201c149/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl#L349-L353) to `external/llvm-project` in a few places; this PR changes those snippets to use the package name passed to `llvm_configure` for this path instead.

I noticed the [TODO](https://github.com/google/llvm-bazel/blob/7d97961847d0576226a6055009da040b6201c149/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl#L349-L350) that was present in some of the places where `llvm-project` is hardcoded; if adding `//mlir:BuiltinDialectTdFiles` and friends as dependencies in the necessary places is preferred I can try to update this PR to do that instead.
