### PR TITLE
Drop visibility from MLIR build

### DIFF
--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD
@@ -10,18 +10,8 @@ load(":linalggen.bzl", "genlinalg")
 load(":build_defs.bzl", "cc_headers_only", "if_cuda_available")
 
 package(
-    default_visibility = [":friends"],
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-package_group(
-    name = "subpackages",
-    packages = ["//mlir/..."],
-)
-
-package_group(
-    name = "friends",
-    packages = ["//..."],
 )
 
 exports_files([
@@ -33,9 +23,6 @@ exports_files([
 filegroup(
     name = "c_headers",
     srcs = glob(["include/mlir-c/**/*"]),  # <== i.e. match the entire tree
-    visibility = [
-        ":friends",
-    ],
 )
 
 [
@@ -5826,37 +5813,34 @@ cc_library(
     ],
 )
 
-exports_files(
-    [
-        "include/mlir/Bindings/Python/Attributes.td",
-        "include/mlir/Interfaces/CallInterfaces.h",
-        "include/mlir/Interfaces/CallInterfaces.td",
-        "include/mlir/Interfaces/CastInterfaces.h",
-        "include/mlir/Interfaces/CastInterfaces.td",
-        "include/mlir/Interfaces/ControlFlowInterfaces.h",
-        "include/mlir/Interfaces/ControlFlowInterfaces.td",
-        "include/mlir/Interfaces/CopyOpInterface.td",
-        "include/mlir/Interfaces/DataLayoutInterfaces.td",
-        "include/mlir/Interfaces/InferTypeOpInterface.td",
-        "include/mlir/Interfaces/LoopLikeInterface.td",
-        "include/mlir/Interfaces/SideEffectInterfaceBase.td",
-        "include/mlir/Interfaces/SideEffectInterfaces.td",
-        "include/mlir/Interfaces/VectorInterfaces.td",
-        "include/mlir/Interfaces/ViewLikeInterface.td",
-        "include/mlir/Dialect/DLTI/DLTIBase.td",
-        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
-        "include/mlir/Dialect/StandardOps/IR/Ops.td",
-        "include/mlir/Dialect/Shape/IR/ShapeOps.td",
-        "include/mlir/Dialect/Shape/IR/ShapeBase.td",
-        "include/mlir/IR/OpAsmInterface.td",
-        "include/mlir/IR/OpBase.td",
-        "include/mlir/IR/RegionKindInterface.td",
-        "include/mlir/IR/SymbolInterfaces.td",
-        "include/mlir/IR/TensorEncoding.td",
-        "include/mlir/Transforms/InliningUtils.h",
-    ],
-    visibility = [":friends"],
-)
+exports_files([
+    "include/mlir/Bindings/Python/Attributes.td",
+    "include/mlir/Interfaces/CallInterfaces.h",
+    "include/mlir/Interfaces/CallInterfaces.td",
+    "include/mlir/Interfaces/CastInterfaces.h",
+    "include/mlir/Interfaces/CastInterfaces.td",
+    "include/mlir/Interfaces/ControlFlowInterfaces.h",
+    "include/mlir/Interfaces/ControlFlowInterfaces.td",
+    "include/mlir/Interfaces/CopyOpInterface.td",
+    "include/mlir/Interfaces/DataLayoutInterfaces.td",
+    "include/mlir/Interfaces/InferTypeOpInterface.td",
+    "include/mlir/Interfaces/LoopLikeInterface.td",
+    "include/mlir/Interfaces/SideEffectInterfaceBase.td",
+    "include/mlir/Interfaces/SideEffectInterfaces.td",
+    "include/mlir/Interfaces/VectorInterfaces.td",
+    "include/mlir/Interfaces/ViewLikeInterface.td",
+    "include/mlir/Dialect/DLTI/DLTIBase.td",
+    "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
+    "include/mlir/Dialect/StandardOps/IR/Ops.td",
+    "include/mlir/Dialect/Shape/IR/ShapeOps.td",
+    "include/mlir/Dialect/Shape/IR/ShapeBase.td",
+    "include/mlir/IR/OpAsmInterface.td",
+    "include/mlir/IR/OpBase.td",
+    "include/mlir/IR/RegionKindInterface.td",
+    "include/mlir/IR/SymbolInterfaces.td",
+    "include/mlir/IR/TensorEncoding.td",
+    "include/mlir/Transforms/InliningUtils.h",
+])
 
 td_library(
     name = "MathOpsTdFiles",

--- a/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
+++ b/llvm-bazel/llvm-project-overlay/mlir/test/BUILD
@@ -5,14 +5,8 @@
 load("//mlir:tblgen.bzl", "gentbl", "td_library")
 
 package(
-    default_visibility = [":test_friends"],
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-# Please only depend on this from MLIR tests.
-package_group(
-    name = "test_friends",
-    packages = ["//..."],
 )
 
 cc_library(


### PR DESCRIPTION
Visibility is a useful restriction within a repo, but across repos it really doesn't work very
well. These visibility markers right now mostly do nothing anyway. Just drop it entirely and
make everything public. I have some vague ideas of how to make Bazel visibility work by
turning it into hooks that a dependent repo can choose to implement, but it's not high on
the list of priorities.