### PR TITLE
[mlir] update gentbl() Bazel macro

### DIFF
--- a/llvm-bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/llvm-bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -5,7 +5,7 @@
 # Description:
 #   The MLIR "Multi-Level Intermediate Representation" Compiler Infrastructure
 
-load(":tblgen.bzl", "gentbl", "td_library")
+load(":tblgen.bzl", "gentbl_cc_library", "td_library")
 load(":linalggen.bzl", "genlinalg")
 load(":build_defs.bzl", "cc_headers_only", "if_cuda_available")
 
@@ -26,16 +26,16 @@ filegroup(
 )
 
 [
-    gentbl(
+    gentbl_cc_library(
         name = name + "IncGen",
         strip_include_prefix = "include",
         tbl_outs = [
             (
-                "-gen-op-interface-decls",
+                ["-gen-op-interface-decls"],
                 "include/mlir/IR/" + name + ".h.inc",
             ),
             (
-                "-gen-op-interface-defs",
+                ["-gen-op-interface-defs"],
                 "include/mlir/IR/" + name + ".cpp.inc",
             ),
         ],
@@ -50,16 +50,16 @@ filegroup(
     ]
 ]
 
-gentbl(
+gentbl_cc_library(
     name = "TensorEncodingIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-attr-interface-decls",
+            ["-gen-attr-interface-decls"],
             "include/mlir/IR/TensorEncInterfaces.h.inc",
         ),
         (
-            "-gen-attr-interface-defs",
+            ["-gen-attr-interface-defs"],
             "include/mlir/IR/TensorEncInterfaces.cpp.inc",
         ),
     ],
@@ -86,12 +86,12 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "BuiltinDialectIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/IR/BuiltinDialect.h.inc",
         ),
     ],
@@ -100,16 +100,16 @@ gentbl(
     deps = [":BuiltinDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "BuiltinAttributesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "--gen-attrdef-decls",
+            ["--gen-attrdef-decls"],
             "include/mlir/IR/BuiltinAttributes.h.inc",
         ),
         (
-            "--gen-attrdef-defs",
+            ["--gen-attrdef-defs"],
             "include/mlir/IR/BuiltinAttributes.cpp.inc",
         ),
     ],
@@ -118,16 +118,16 @@ gentbl(
     deps = [":BuiltinDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "BuiltinLocationAttributesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "--gen-attrdef-decls",
+            ["--gen-attrdef-decls"],
             "include/mlir/IR/BuiltinLocationAttributes.h.inc",
         ),
         (
-            "--gen-attrdef-defs",
+            ["--gen-attrdef-defs"],
             "include/mlir/IR/BuiltinLocationAttributes.cpp.inc",
         ),
     ],
@@ -136,16 +136,16 @@ gentbl(
     deps = [":BuiltinDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "BuiltinOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/IR/BuiltinOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/IR/BuiltinOps.cpp.inc",
         ),
     ],
@@ -154,16 +154,16 @@ gentbl(
     deps = [":BuiltinDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "BuiltinTypesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "--gen-typedef-decls",
+            ["--gen-typedef-decls"],
             "include/mlir/IR/BuiltinTypes.h.inc",
         ),
         (
-            "--gen-typedef-defs",
+            ["--gen-typedef-defs"],
             "include/mlir/IR/BuiltinTypes.cpp.inc",
         ),
     ],
@@ -714,20 +714,20 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AffineOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Affine/IR/AffineOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Affine/IR/AffineOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/Affine/IR/AffineOpsDialect.h.inc",
         ),
     ],
@@ -736,16 +736,16 @@ gentbl(
     deps = [":AffineOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AffineMemoryOpInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.cpp.inc",
         ),
     ],
@@ -773,28 +773,28 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AsyncOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Async/IR/AsyncOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Async/IR/AsyncOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/Async/IR/AsyncOpsDialect.h.inc",
         ),
         (
-            "-gen-typedef-decls",
+            ["-gen-typedef-decls"],
             "include/mlir/Dialect/Async/IR/AsyncOpsTypes.h.inc",
         ),
         (
-            "-gen-typedef-defs",
+            ["-gen-typedef-defs"],
             "include/mlir/Dialect/Async/IR/AsyncOpsTypes.cpp.inc",
         ),
     ],
@@ -803,20 +803,29 @@ gentbl(
     deps = [":AsyncOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AsyncPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Async",
+            [
+                "-gen-pass-decls",
+                "-name=Async",
+            ],
             "include/mlir/Dialect/Async/Passes.h.inc",
         ),
         (
-            "-gen-pass-capi-header --prefix Async",
+            [
+                "-gen-pass-capi-header",
+                "--prefix=Async",
+            ],
             "include/mlir/Dialect/Async/Passes.capi.h.inc",
         ),
         (
-            "-gen-pass-capi-impl --prefix Async",
+            [
+                "-gen-pass-capi-impl",
+                "--prefix=Async",
+            ],
             "include/mlir/Dialect/Async/Passes.capi.cpp.inc",
         ),
     ],
@@ -839,24 +848,27 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ArmNeonIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect arm_neon",
+            [
+                "-gen-dialect-decls",
+                "-dialect=arm_neon",
+            ],
             "include/mlir/Dialect/ArmNeon/ArmNeonDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/ArmNeon/ArmNeon.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/ArmNeon/ArmNeon.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/ArmNeon/ArmNeon.md",
         ),
     ],
@@ -880,12 +892,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ArmNeonConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/ArmNeon/ArmNeonConversions.inc",
         ),
     ],
@@ -911,28 +923,31 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ArmSVEIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/ArmSVE/ArmSVE.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/ArmSVE/ArmSVE.cpp.inc",
         ),
         (
-            "-gen-typedef-decls",
+            ["-gen-typedef-decls"],
             "include/mlir/Dialect/ArmSVE/ArmSVETypes.h.inc",
         ),
         (
-            "-gen-typedef-defs",
+            ["-gen-typedef-defs"],
             "include/mlir/Dialect/ArmSVE/ArmSVETypes.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect arm_sve",
+            [
+                "-gen-dialect-decls",
+                "-dialect=arm_sve",
+            ],
             "include/mlir/Dialect/ArmSVE/ArmSVEDialect.h.inc",
         ),
     ],
@@ -975,12 +990,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ArmSVEConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/ArmSVE/ArmSVEConversions.inc",
         ),
     ],
@@ -1003,24 +1018,27 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AMXIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=amx",
+            [
+                "-gen-dialect-decls",
+                "-dialect=amx",
+            ],
             "include/mlir/Dialect/AMX/AMXDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/AMX/AMX.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/AMX/AMX.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/AMX/AMX.md",
         ),
     ],
@@ -1060,12 +1078,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AMXConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/AMX/AMXConversions.inc",
         ),
     ],
@@ -1088,24 +1106,27 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "X86VectorIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=x86vector",
+            [
+                "-gen-dialect-decls",
+                "-dialect=x86vector",
+            ],
             "include/mlir/Dialect/X86Vector/X86VectorDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/X86Vector/X86Vector.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/X86Vector/X86Vector.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/X86Vector/X86Vector.md",
         ),
     ],
@@ -1145,12 +1166,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "X86VectorConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/X86Vector/X86VectorConversions.inc",
         ),
     ],
@@ -1174,20 +1195,20 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SCFIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/SCF/SCFOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/SCF/SCFOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/SCF/SCFOpsDialect.h.inc",
         ),
     ],
@@ -1196,12 +1217,15 @@ gentbl(
     deps = [":SCFTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SCFPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name SCF",
+            [
+                "-gen-pass-decls",
+                "-name=SCF",
+            ],
             "include/mlir/Dialect/SCF/Passes.h.inc",
         ),
     ],
@@ -1249,16 +1273,16 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SparseTensorAttrDefsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "--gen-attrdef-decls",
+            ["--gen-attrdef-decls"],
             "include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.h.inc",
         ),
         (
-            "--gen-attrdef-defs",
+            ["--gen-attrdef-defs"],
             "include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.cpp.inc",
         ),
     ],
@@ -1267,24 +1291,27 @@ gentbl(
     deps = [":SparseTensorTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SparseTensorOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=sparse_tensor",
+            [
+                "-gen-dialect-decls",
+                "-dialect=sparse_tensor",
+            ],
             "include/mlir/Dialect/SparseTensor/IR/SparseTensorOpsDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/SparseTensor/IR/SparseTensorOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/SparseTensor/IR/SparseTensorOps.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/SparseTensor/SparseTensor.md",
         ),
     ],
@@ -1293,12 +1320,15 @@ gentbl(
     deps = [":SparseTensorTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SparseTensorPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name SparseTensor",
+            [
+                "-gen-pass-decls",
+                "-name=SparseTensor",
+            ],
             "include/mlir/Dialect/SparseTensor/Transforms/Passes.h.inc",
         ),
     ],
@@ -1363,28 +1393,28 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "StandardOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/StandardOps/IR/Ops.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/StandardOps/IR/Ops.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/StandardOps/IR/OpsDialect.h.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/StandardOps/IR/OpsEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/StandardOps/IR/OpsEnums.cpp.inc",
         ),
     ],
@@ -1520,12 +1550,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "AffinePassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Affine",
+            [
+                "-gen-pass-decls",
+                "-name=Affine",
+            ],
             "include/mlir/Dialect/Affine/Passes.h.inc",
         ),
     ],
@@ -1559,20 +1592,29 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ConversionPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Conversion",
+            [
+                "-gen-pass-decls",
+                "-name=Conversion",
+            ],
             "include/mlir/Conversion/Passes.h.inc",
         ),
         (
-            "-gen-pass-capi-header --prefix Conversion",
+            [
+                "-gen-pass-capi-header",
+                "--prefix=Conversion",
+            ],
             "include/mlir/Conversion/Passes.capi.h.inc",
         ),
         (
-            "-gen-pass-capi-impl --prefix Conversion",
+            [
+                "-gen-pass-capi-impl",
+                "--prefix=Conversion",
+            ],
             "include/mlir/Conversion/Passes.capi.cpp.inc",
         ),
     ],
@@ -1807,20 +1849,20 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ShapeOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Shape/IR/ShapeOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Shape/IR/ShapeOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/Shape/IR/ShapeOpsDialect.h.inc",
         ),
     ],
@@ -1829,12 +1871,12 @@ gentbl(
     deps = [":ShapeOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MLIRShapeCanonicalizationIncGen",
     strip_include_prefix = "include/mlir/Dialect/Shape/IR",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "include/mlir/Dialect/Shape/IR/ShapeCanonicalization.inc",
         ),
     ],
@@ -1869,12 +1911,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ShapeToStandardGen",
     strip_include_prefix = "lib/Conversion/ShapeToStandard",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Conversion/ShapeToStandard/ShapeToStandard.cpp.inc",
         ),
     ],
@@ -1907,11 +1949,14 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ShapeTransformsPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [(
-        "-gen-pass-decls -name Shape",
+        [
+            "-gen-pass-decls",
+            "-name=Shape",
+        ],
         "include/mlir/Dialect/Shape/Transforms/Passes.h.inc",
     )],
     tblgen = ":mlir-tblgen",
@@ -1971,11 +2016,14 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "StandardOpsTransformsPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [(
-        "-gen-pass-decls -name Standard",
+        [
+            "-gen-pass-decls",
+            "-name=Standard",
+        ],
         "include/mlir/Dialect/StandardOps/Transforms/Passes.h.inc",
     )],
     tblgen = ":mlir-tblgen",
@@ -2111,16 +2159,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LLVMDialectInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.cpp.inc",
         ),
     ],
@@ -2129,16 +2177,16 @@ gentbl(
     deps = [":LLVMOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LLVMDialectAttributesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "--gen-attrdef-decls",
+            ["--gen-attrdef-decls"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.h.inc",
         ),
         (
-            "--gen-attrdef-defs",
+            ["--gen-attrdef-defs"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.cpp.inc",
         ),
     ],
@@ -2194,12 +2242,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LLVMPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name LLVM",
+            [
+                "-gen-pass-decls",
+                "-name=LLVM",
+            ],
             "include/mlir/Dialect/LLVMIR/Transforms/Passes.h.inc",
         ),
     ],
@@ -2240,24 +2291,24 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ParallelLoopMapperAttrGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-struct-attr-decls",
+            ["-gen-struct-attr-decls"],
             "include/mlir/Dialect/GPU/ParallelLoopMapperAttr.h.inc",
         ),
         (
-            "-gen-struct-attr-defs",
+            ["-gen-struct-attr-defs"],
             "include/mlir/Dialect/GPU/ParallelLoopMapperAttr.cpp.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/GPU/ParallelLoopMapperEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/GPU/ParallelLoopMapperEnums.cpp.inc",
         ),
     ],
@@ -2266,20 +2317,23 @@ gentbl(
     deps = [":GPUOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUBaseIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=gpu",
+            [
+                "-gen-dialect-decls",
+                "-dialect=gpu",
+            ],
             "include/mlir/Dialect/GPU/GPUOpsDialect.h.inc",
         ),
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Dialect/GPU/GPUOpInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Dialect/GPU/GPUOpInterfaces.cpp.inc",
         ),
     ],
@@ -2288,16 +2342,16 @@ gentbl(
     deps = [":GPUOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/GPU/GPUOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/GPU/GPUOps.cpp.inc",
         ),
     ],
@@ -2332,20 +2386,29 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name GPU",
+            [
+                "-gen-pass-decls",
+                "-name=GPU",
+            ],
             "include/mlir/Dialect/GPU/Passes.h.inc",
         ),
         (
-            "-gen-pass-capi-header --prefix GPU",
+            [
+                "-gen-pass-capi-header",
+                "--prefix=GPU",
+            ],
             "include/mlir/Dialect/GPU/Passes.capi.h.inc",
         ),
         (
-            "-gen-pass-capi-impl --prefix GPU",
+            [
+                "-gen-pass-capi-impl",
+                "--prefix=GPU",
+            ],
             "include/mlir/Dialect/GPU/Passes.capi.cpp.inc",
         ),
     ],
@@ -2433,12 +2496,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUToNVVMGen",
     strip_include_prefix = "lib/Conversion/GPUToNVVM",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Conversion/GPUToNVVM/GPUToNVVM.cpp.inc",
         ),
     ],
@@ -2518,12 +2581,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUToROCDLTGen",
     strip_include_prefix = "lib/Conversion/GPUToROCDL",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Conversion/GPUToROCDL/GPUToROCDL.cpp.inc",
         ),
     ],
@@ -2610,12 +2673,12 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "GPUToSPIRVIncGen",
     strip_include_prefix = "lib/Conversion/GPUToSPIRV",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp.inc",
         ),
     ],
@@ -2703,28 +2766,28 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LLVMOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/LLVMIR/LLVMOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/LLVMIR/LLVMOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsDialect.h.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/LLVMIR/LLVMOpsEnums.cpp.inc",
         ),
     ],
@@ -2733,20 +2796,20 @@ gentbl(
     deps = [":LLVMOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LLVMConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/LLVMIR/LLVMConversions.inc",
         ),
         (
-            "-gen-enum-to-llvmir-conversions",
+            ["-gen-enum-to-llvmir-conversions"],
             "include/mlir/Dialect/LLVMIR/LLVMConversionEnumsToLLVM.inc",
         ),
         (
-            "-gen-enum-from-llvmir-conversions",
+            ["-gen-enum-from-llvmir-conversions"],
             "include/mlir/Dialect/LLVMIR/LLVMConversionEnumsFromLLVM.inc",
         ),
     ],
@@ -2784,20 +2847,23 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "NVVMOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/LLVMIR/NVVMOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/LLVMIR/NVVMOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=nvvm",
+            [
+                "-gen-dialect-decls",
+                "-dialect=nvvm",
+            ],
             "include/mlir/Dialect/LLVMIR/NVVMOpsDialect.h.inc",
         ),
     ],
@@ -2806,12 +2872,12 @@ gentbl(
     deps = [":NVVMOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "NVVMConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/LLVMIR/NVVMConversions.inc",
         ),
     ],
@@ -2849,20 +2915,23 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ROCDLOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/LLVMIR/ROCDLOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/LLVMIR/ROCDLOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=rocdl",
+            [
+                "-gen-dialect-decls",
+                "-dialect=rocdl",
+            ],
             "include/mlir/Dialect/LLVMIR/ROCDLOpsDialect.h.inc",
         ),
     ],
@@ -2871,12 +2940,12 @@ gentbl(
     deps = [":ROCDLOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ROCDLConversionIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-llvmir-conversions",
+            ["-gen-llvmir-conversions"],
             "include/mlir/Dialect/LLVMIR/ROCDLConversions.inc",
         ),
     ],
@@ -2919,20 +2988,20 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "PDLOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/PDL/IR/PDLOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/PDL/IR/PDLOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/PDL/IR/PDLOpsDialect.h.inc",
         ),
     ],
@@ -2941,16 +3010,16 @@ gentbl(
     deps = [":PDLDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "PDLTypesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-typedef-decls",
+            ["-gen-typedef-decls"],
             "include/mlir/Dialect/PDL/IR/PDLOpsTypes.h.inc",
         ),
         (
-            "-gen-typedef-defs",
+            ["-gen-typedef-defs"],
             "include/mlir/Dialect/PDL/IR/PDLOpsTypes.cpp.inc",
         ),
     ],
@@ -2991,20 +3060,23 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "PDLInterpOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=pdl_interp",
+            [
+                "-gen-dialect-decls",
+                "-dialect=pdl_interp",
+            ],
             "include/mlir/Dialect/PDLInterp/IR/PDLInterpOpsDialect.h.inc",
         ),
     ],
@@ -3025,44 +3097,44 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVOpsDialect.h.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/SPIRV/SPIRVOps.md",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVEnums.cpp.inc",
         ),
         (
-            "-gen-spirv-enum-avail-decls",
+            ["-gen-spirv-enum-avail-decls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVEnumAvailability.h.inc",
         ),
         (
-            "-gen-spirv-enum-avail-defs",
+            ["-gen-spirv-enum-avail-defs"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVEnumAvailability.cpp.inc",
         ),
         (
-            "-gen-spirv-capability-implication",
+            ["-gen-spirv-capability-implication"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVCapabilityImplication.inc",
         ),
     ],
@@ -3071,12 +3143,12 @@ gentbl(
     deps = [":SPIRVOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVCanonicalizationIncGen",
     strip_include_prefix = "lib/Dialect/SPIRV/IR",
     tbl_outs = [
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Dialect/SPIRV/IR/SPIRVCanonicalization.inc",
         ),
     ],
@@ -3085,20 +3157,20 @@ gentbl(
     deps = [":SPIRVOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVAvailabilityIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-avail-interface-decls",
+            ["-gen-avail-interface-decls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVAvailability.h.inc",
         ),
         (
-            "-gen-avail-interface-defs",
+            ["-gen-avail-interface-defs"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVAvailability.cpp.inc",
         ),
         (
-            "-gen-spirv-avail-impls",
+            ["-gen-spirv-avail-impls"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVOpAvailabilityImpl.inc",
         ),
     ],
@@ -3107,15 +3179,15 @@ gentbl(
     deps = [":SPIRVOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVTargetAndABIStructGen",
     tbl_outs = [
         (
-            "-gen-struct-attr-decls",
+            ["-gen-struct-attr-decls"],
             "include/mlir/Dialect/SPIRV/IR/TargetAndABI.h.inc",
         ),
         (
-            "-gen-struct-attr-defs",
+            ["-gen-struct-attr-defs"],
             "include/mlir/Dialect/SPIRV/IR/TargetAndABI.cpp.inc",
         ),
     ],
@@ -3124,12 +3196,12 @@ gentbl(
     deps = [":SPIRVOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVAttrUtilsGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-spirv-attr-utils",
+            ["-gen-spirv-attr-utils"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVAttrUtils.inc",
         ),
     ],
@@ -3138,12 +3210,12 @@ gentbl(
     deps = [":SPIRVOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVSerializationGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-spirv-serialization",
+            ["-gen-spirv-serialization"],
             "include/mlir/Dialect/SPIRV/IR/SPIRVSerialization.inc",
         ),
     ],
@@ -3181,12 +3253,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SPIRVPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name SPIRV",
+            [
+                "-gen-pass-decls",
+                "-name=SPIRV",
+            ],
             "include/mlir/Dialect/SPIRV/Transforms/Passes.h.inc",
         ),
     ],
@@ -3387,20 +3462,23 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TensorOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=tensor",
+            [
+                "-gen-dialect-decls",
+                "-dialect=tensor",
+            ],
             "include/mlir/Dialect/Tensor/IR/TensorOpsDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Tensor/IR/TensorOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Tensor/IR/TensorOps.cpp.inc",
         ),
     ],
@@ -3430,12 +3508,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TensorPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Tensor",
+            [
+                "-gen-pass-decls",
+                "-name=Tensor",
+            ],
             "include/mlir/Dialect/Tensor/Transforms/Passes.h.inc",
         ),
     ],
@@ -3518,16 +3599,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "DerivedAttributeOpInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/DerivedAttributeOpInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/DerivedAttributeOpInterface.cpp.inc",
         ),
     ],
@@ -3555,31 +3636,31 @@ td_library(
     includes = ["include"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "DataLayoutInterfacesIncGen",
     tbl_outs = [
         (
-            "-gen-attr-interface-decls",
+            ["-gen-attr-interface-decls"],
             "include/mlir/Interfaces/DataLayoutAttrInterface.h.inc",
         ),
         (
-            "-gen-attr-interface-defs",
+            ["-gen-attr-interface-defs"],
             "include/mlir/Interfaces/DataLayoutAttrInterface.cpp.inc",
         ),
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/DataLayoutOpInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/DataLayoutOpInterface.cpp.inc",
         ),
         (
-            "-gen-type-interface-decls",
+            ["-gen-type-interface-decls"],
             "include/mlir/Interfaces/DataLayoutTypeInterface.h.inc",
         ),
         (
-            "-gen-type-interface-defs",
+            ["-gen-type-interface-defs"],
             "include/mlir/Interfaces/DataLayoutTypeInterface.cpp.inc",
         ),
     ],
@@ -3588,16 +3669,16 @@ gentbl(
     deps = [":OpBaseTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LoopLikeInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/LoopLikeInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/LoopLikeInterface.cpp.inc",
         ),
     ],
@@ -3606,16 +3687,16 @@ gentbl(
     deps = [":LoopLikeInterfaceTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "VectorInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/VectorInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/VectorInterfaces.cpp.inc",
         ),
     ],
@@ -3624,16 +3705,16 @@ gentbl(
     deps = [":VectorInterfacesTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ViewLikeInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/ViewLikeInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/ViewLikeInterface.cpp.inc",
         ),
     ],
@@ -3642,16 +3723,16 @@ gentbl(
     deps = [":ViewLikeInterfaceTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "CopyOpInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/CopyOpInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/CopyOpInterface.cpp.inc",
         ),
     ],
@@ -3660,20 +3741,29 @@ gentbl(
     deps = [":CopyOpInterfaceTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TransformsPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Transforms",
+            [
+                "-gen-pass-decls",
+                "-name=Transforms",
+            ],
             "include/mlir/Transforms/Passes.h.inc",
         ),
         (
-            "-gen-pass-capi-header --prefix Transforms",
+            [
+                "-gen-pass-capi-header",
+                "--prefix=Transforms",
+            ],
             "include/mlir/Transforms/Transforms.capi.h.inc",
         ),
         (
-            "-gen-pass-capi-impl --prefix Transforms",
+            [
+                "-gen-pass-capi-impl",
+                "--prefix=Transforms",
+            ],
             "include/mlir/Transforms/Transforms.capi.cpp.inc",
         ),
     ],
@@ -3877,16 +3967,16 @@ alias(
     actual = "StandardToLLVM",
 )
 
-gentbl(
+gentbl_cc_library(
     name = "CallOpInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/CallInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/CallInterfaces.cpp.inc",
         ),
     ],
@@ -3908,16 +3998,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "CastOpInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/CastInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/CastInterfaces.cpp.inc",
         ),
     ],
@@ -3939,16 +4029,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ControlFlowInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/ControlFlowInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/ControlFlowInterfaces.cpp.inc",
         ),
     ],
@@ -3970,16 +4060,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "InferTypeOpInterfaceIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/InferTypeOpInterface.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/InferTypeOpInterface.cpp.inc",
         ),
     ],
@@ -4001,16 +4091,16 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "SideEffectInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Interfaces/SideEffectInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Interfaces/SideEffectInterfaces.cpp.inc",
         ),
     ],
@@ -4812,13 +4902,13 @@ cc_binary(
 ## OpenACC dialect
 
 # TODO(gcmn): This is sticking td files in a cc_library
-gentbl(
+gentbl_cc_library(
     name = "AccCommonGen",
     includes = ["/llvm/include"],
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-directive-decl",
+            ["-gen-directive-decl"],
             "include/mlir/Dialect/OpenACC/AccCommon.td",
         ),
     ],
@@ -4837,32 +4927,35 @@ td_library(
     deps = [":OpBaseTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "OpenACCOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=acc",
+            [
+                "-gen-dialect-decls",
+                "-dialect=acc",
+            ],
             "include/mlir/Dialect/OpenACC/OpenACCOpsDialect.h.inc",
         ),
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/OpenACC/OpenACCOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/OpenACC/OpenACCOps.cpp.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/OpenACC/OpenACCOpsEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/OpenACC/OpenACCOpsEnums.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/OpenACC/OpenACCOps.md",
         ),
     ],
@@ -4894,13 +4987,13 @@ cc_library(
 ## OpenMP dialect
 
 # TODO(gcmn): This is sticking td files in a cc_library
-gentbl(
+gentbl_cc_library(
     name = "OmpCommonTdGen",
     includes = ["/llvm/include"],
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-directive-decl",
+            ["-gen-directive-decl"],
             "include/mlir/Dialect/OpenMP/OmpCommon.td",
         ),
     ],
@@ -4924,32 +5017,35 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "OpenMPOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/OpenMP/OpenMPOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/OpenMP/OpenMPOps.cpp.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/OpenMP/OpenMPOpsEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/OpenMP/OpenMPOpsEnums.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=omp",
+            [
+                "-gen-dialect-decls",
+                "-dialect=omp",
+            ],
             "include/mlir/Dialect/OpenMP/OpenMPOpsDialect.h.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/OpenMP/OpenMPOps.md",
         ),
     ],
@@ -5018,24 +5114,24 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "QuantOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Quant/QuantOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Quant/QuantOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/Quant/QuantOpsDialect.h.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/QuantOps/QuantOps.md",
         ),
     ],
@@ -5044,12 +5140,15 @@ gentbl(
     deps = [":QuantizationOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "QuantPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Quant",
+            [
+                "-gen-pass-decls",
+                "-name=Quant",
+            ],
             "include/mlir/Dialect/Quant/Passes.h.inc",
         ),
     ],
@@ -5110,20 +5209,23 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LinalgOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Linalg/IR/LinalgOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Linalg/IR/LinalgOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=linalg",
+            [
+                "-gen-dialect-decls",
+                "-dialect=linalg",
+            ],
             "include/mlir/Dialect/Linalg/IR/LinalgOpsDialect.h.inc",
         ),
     ],
@@ -5181,16 +5283,16 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LinalgStructuredOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc",
         ),
     ],
@@ -5199,16 +5301,16 @@ gentbl(
     deps = [":LinalgStructuredOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LinalgInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Dialect/Linalg/IR/LinalgInterfaces.cpp.inc",
         ),
     ],
@@ -5227,12 +5329,12 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LinalgDocIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/Linalg/LinalgOps.md",
         ),
     ],
@@ -5360,20 +5462,29 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "LinalgPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Linalg",
+            [
+                "-gen-pass-decls",
+                "-name=Linalg",
+            ],
             "include/mlir/Dialect/Linalg/Passes.h.inc",
         ),
         (
-            "-gen-pass-capi-header --prefix Linalg",
+            [
+                "-gen-pass-capi-header",
+                "--prefix=Linalg",
+            ],
             "include/mlir/Dialect/Linalg/Passes.capi.h.inc",
         ),
         (
-            "-gen-pass-capi-impl --prefix Linalg",
+            [
+                "-gen-pass-capi-impl",
+                "--prefix=Linalg",
+            ],
             "include/mlir/Dialect/Linalg/Passes.capi.cpp.inc",
         ),
     ],
@@ -5450,32 +5561,35 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "VectorOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Vector/VectorOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Vector/VectorOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=vector",
+            [
+                "-gen-dialect-decls",
+                "-dialect=vector",
+            ],
             "include/mlir/Dialect/Vector/VectorOpsDialect.h.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "include/mlir/Dialect/Vector/VectorOpsEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "include/mlir/Dialect/Vector/VectorOpsEnums.cpp.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/Vector/VectorOps.md",
         ),
     ],
@@ -5559,32 +5673,32 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TosaDialectIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Tosa/IR/TosaOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Tosa/IR/TosaOps.cpp.inc",
         ),
         (
-            "-gen-struct-attr-decls",
+            ["-gen-struct-attr-decls"],
             "include/mlir/Dialect/Tosa/IR/TosaStructs.h.inc",
         ),
         (
-            "-gen-struct-attr-defs",
+            ["-gen-struct-attr-defs"],
             "include/mlir/Dialect/Tosa/IR/TosaStructs.cpp.inc",
         ),
         (
-            "-gen-dialect-decls",
+            ["-gen-dialect-decls"],
             "include/mlir/Dialect/Tosa/IR/TosaOpsDialect.h.inc",
         ),
         (
-            "-gen-op-doc",
+            ["-gen-op-doc"],
             "g3doc/Dialects/Tosa/TosaOps.md",
         ),
     ],
@@ -5593,16 +5707,16 @@ gentbl(
     deps = [":TosaDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TosaInterfacesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "include/mlir/Dialect/Tosa/IR/TosaInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "include/mlir/Dialect/Tosa/IR/TosaInterfaces.cpp.inc",
         ),
     ],
@@ -5611,12 +5725,15 @@ gentbl(
     deps = [":TosaDialectTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TosaPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name TosaOpt",
+            [
+                "-gen-pass-decls",
+                "-name=TosaOpt",
+            ],
             "include/mlir/Dialect/Tosa/Transforms/Passes.h.inc",
         ),
     ],
@@ -5743,12 +5860,15 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ComplexBaseIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=complex",
+            [
+                "-gen-dialect-decls",
+                "-dialect=complex",
+            ],
             "include/mlir/Dialect/Complex/IR/ComplexOpsDialect.h.inc",
         ),
     ],
@@ -5757,16 +5877,16 @@ gentbl(
     deps = [":ComplexOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ComplexOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Complex/IR/ComplexOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Complex/IR/ComplexOps.cpp.inc",
         ),
     ],
@@ -5884,12 +6004,15 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MathBaseIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=math",
+            [
+                "-gen-dialect-decls",
+                "-dialect=math",
+            ],
             "include/mlir/Dialect/Math/IR/MathOpsDialect.h.inc",
         ),
     ],
@@ -5898,16 +6021,16 @@ gentbl(
     deps = [":MathOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MathOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/Math/IR/MathOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/Math/IR/MathOps.cpp.inc",
         ),
     ],
@@ -6005,12 +6128,15 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MemRefBaseIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=memref",
+            [
+                "-gen-dialect-decls",
+                "-dialect=memref",
+            ],
             "include/mlir/Dialect/MemRef/IR/MemRefOpsDialect.h.inc",
         ),
     ],
@@ -6019,16 +6145,16 @@ gentbl(
     deps = [":MemRefOpsTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MemRefOpsIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "include/mlir/Dialect/MemRef/IR/MemRefOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "include/mlir/Dialect/MemRef/IR/MemRefOps.cpp.inc",
         ),
     ],
@@ -6066,12 +6192,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "MemRefPassIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name MemRef",
+            [
+                "-gen-pass-decls",
+                "-name=MemRef",
+            ],
             "include/mlir/Dialect/MemRef/Transforms/Passes.h.inc",
         ),
     ],
@@ -6114,12 +6243,15 @@ td_library(
     deps = [":OpBaseTdFiles"],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "DLTIBaseIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-dialect-decls -dialect=dlti",
+            [
+                "-gen-dialect-decls",
+                "-dialect=dlti",
+            ],
             "include/mlir/Dialect/DLTI/DLTIDialect.h.inc",
         ),
     ],
@@ -6141,12 +6273,15 @@ cc_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "ReducerIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            "-gen-pass-decls -name Reducer",
+            [
+                "-gen-pass-decls",
+                "-name=Reducer",
+            ],
             "include/mlir/Reducer/Passes.h.inc",
         ),
     ],

--- a/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/llvm-bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -4,12 +4,12 @@
 """BUILD extensions for MLIR table generation."""
 
 TdInfo = provider(
-    "Holds tablegen files and the dependencies and include paths necessary to" +
+    "Holds TableGen files and the dependencies and include paths necessary to" +
     " build them.",
     fields = {
         "transitive_sources": "td files transitively used by this rule.",
         "transitive_includes": (
-            "include arguments to add to the final tablegen invocation. These" +
+            "include arguments to add to the final TableGen invocation. These" +
             " are the absolute directory paths that will be added with '-I'."
         ),
     },
@@ -109,14 +109,14 @@ td_library = rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "includes": attr.string_list(
-            doc = "Include paths to be added to the final tablegen tool" +
+            doc = "Include paths to be added to the final TableGen tool" +
                   " invocation. Relative paths are interpreted as relative to" +
                   " the current label's package. Absolute paths are" +
                   " interpreted as relative to the current label's workspace",
         ),
         # TODO(gcmn): limit to TdInfo providers.
         "deps": attr.label_list(
-            doc = "Dependencies providing tablegen source files and include" +
+            doc = "Dependencies providing TableGen source files and include" +
                   " paths.",
         ),
     },
@@ -156,6 +156,7 @@ def _gentbl_rule_impl(ctx):
         inputs = trans_srcs,
         executable = ctx.executable.tblgen,
         arguments = [args],
+        mnemonic = "TdGenerate",
     )
 
     return [DefaultInfo()]
@@ -167,36 +168,36 @@ gentbl_rule = rule(
     output_to_genfiles = True,
     attrs = {
         "tblgen": attr.label(
-            doc = "The tablegen executable with which to generate `out`.",
+            doc = "The TableGen executable with which to generate `out`.",
             executable = True,
             cfg = "exec",
         ),
         "td_file": attr.label(
-            doc = "The tablegen file to run through `tblgen`.",
+            doc = "The TableGen file to run through `tblgen`.",
             allow_single_file = True,
             mandatory = True,
         ),
         "td_srcs": attr.label_list(
-            doc = "Additional tablegen files included by `td_file`. It is not" +
+            doc = "Additional TableGen files included by `td_file`. It is not" +
                   " necessary to list td_file here (though not an error).",
             allow_files = True,
         ),
         # TODO(gcmn): limit to TdInfo providers.
         "deps": attr.label_list(
-            doc = "Dependencies providing tablegen source files and include" +
+            doc = "Dependencies providing TableGen source files and include" +
                   " paths.",
         ),
         "out": attr.output(
-            doc = "The output file for the tablegen invocation.",
+            doc = "The output file for the TableGen invocation.",
             mandatory = True,
         ),
         "opts": attr.string_list(
-            doc = "Additional command line options to add to the tablegen" +
+            doc = "Additional command line options to add to the TableGen" +
                   " invocation. For include arguments, prefer to use" +
                   " `includes`.",
         ),
         "includes": attr.string_list(
-            doc = "Include paths to be added to the final tablegen tool" +
+            doc = "Include paths to be added to the final TableGen tool" +
                   " invocation. Relative paths are interpreted as relative to" +
                   " the current label's package. Absolute paths are" +
                   " interpreted as relative to the current label's workspace." +
@@ -206,7 +207,7 @@ gentbl_rule = rule(
                   " directory of td_file are always added.",
         ),
         "td_includes": attr.string_list(
-            doc = "Include paths to add to the tablegen invocation. Paths are" +
+            doc = "Include paths to add to the TableGen invocation. Paths are" +
                   " interpreted as relative to the current label's workspace" +
                   " root and applied from all roots available in the" +
                   " execution environment (source, genfiles, and bin" +
@@ -261,7 +262,7 @@ def _gentbl_test_impl(ctx):
 gentbl_test = rule(
     _gentbl_test_impl,
     test = True,
-    doc = "A shell test that tests the given tablegen invocation. Note" +
+    doc = "A shell test that tests the given TablegGen invocation. Note" +
           " that unlike gentbl_rule, this builds and invokes `tblgen` in the" +
           " target configuration. Takes all the same arguments as gentbl_rule" +
           " except for `out` (as it does not generate any output)",
@@ -269,7 +270,7 @@ gentbl_test = rule(
     output_to_genfiles = True,
     attrs = {
         "tblgen": attr.label(
-            doc = "The tablegen executable run in the shell command. Note" +
+            doc = "The TableGen executable run in the shell command. Note" +
                   " that this is built in the target configuration.",
             executable = True,
             cfg = "target",
@@ -290,7 +291,94 @@ gentbl_test = rule(
     },
 )
 
-def gentbl(
+def gentbl_filegroup(
+        name,
+        tblgen,
+        td_file,
+        tbl_outs,
+        td_srcs = [],
+        td_includes = [],
+        includes = [],
+        deps = [],
+        test = False,
+        skip_opts = [],
+        **kwargs):
+    """Create multiple TableGen generated files using the same tool and input.
+
+    All generated outputs are bundled in a file group with the given name.
+
+    Args:
+      name: The name of the generated filegroup rule for use in dependencies.
+      tblgen: The binary used to produce the output.
+      td_file: The primary table definitions file.
+      tbl_outs: A list of tuples ([opts], out), where each 'opts' is a list of
+        options passed to tblgen, each option being a string, and 'out' is the
+        corresponding output file produced.
+      td_srcs: See gentbl_rule.td_srcs
+      includes: See gentbl_rule.includes
+      td_includes: See gentbl_rule.td_includes
+      deps: See gentbl_rule.deps
+      test: Whether to create a shell test that invokes the tool too.
+      skip_opts: Files generated using these opts in tbl_outs will be excluded
+        from the generated filegroup.
+      **kwargs: Extra keyword arguments to pass to all generated rules.
+    """
+
+    llvm_project_execroot_path = Label("//mlir:tblgen.bzl", relative_to_caller_repository = False).workspace_root
+
+    # TODO(gcmn): Update callers to td_library and explicit includes and drop
+    # this hardcoded include.
+    hardcoded_includes = [
+        "%s/mlir/include" % llvm_project_execroot_path,
+    ]
+
+    for (opts, out) in tbl_outs:
+        first_opt = opts[0] if opts else ""
+        rule_suffix = "_{}_{}".format(
+            first_opt.replace("-", "_").replace("=", "_"),
+            str(hash(" ".join(opts))),
+        )
+        gentbl_name = "%s_%s_genrule" % (name, rule_suffix)
+        gentbl_rule(
+            name = gentbl_name,
+            td_file = td_file,
+            tblgen = tblgen,
+            opts = opts,
+            td_srcs = td_srcs,
+            deps = deps,
+            includes = includes,
+            td_includes = td_includes + hardcoded_includes,
+            out = out,
+            **kwargs
+        )
+
+        if test:
+            # Also run the generator in the target configuration as a test. This
+            # means it gets run with asserts and sanitizers and such when they
+            # are enabled and is counted in coverage.
+            gentbl_test(
+                name = "%s_test" % (gentbl_name,),
+                td_file = td_file,
+                tblgen = tblgen,
+                opts = opts,
+                td_srcs = td_srcs,
+                deps = deps,
+                includes = includes,
+                td_includes = td_includes + hardcoded_includes,
+                # Shell files not executable on Windows.
+                # TODO(gcmn): Support windows.
+                tags = ["no_windows"],
+                **kwargs
+            )
+
+    included_srcs = [f for (opts, f) in tbl_outs if not any([skip_opt in opts for skip_opt in skip_opts])]
+    native.filegroup(
+        name = name,
+        srcs = included_srcs,
+        **kwargs
+    )
+
+def gentbl_cc_library(
         name,
         tblgen,
         td_file,
@@ -303,7 +391,7 @@ def gentbl(
         strip_include_prefix = None,
         test = False,
         **kwargs):
-    """Create multiple tablegen generated files using the same tool and input.
+    """Create multiple TableGen generated files using the same tool and input.
 
     All generated outputs are bundled in a cc_library rule.
 
@@ -311,9 +399,9 @@ def gentbl(
       name: The name of the generated cc_library rule for use in dependencies.
       tblgen: The binary used to produce the output.
       td_file: The primary table definitions file.
-      tbl_outs: A list of tuples (opts, out), where each opts is a string of
-        options passed to tblgen, and the out is the corresponding output file
-        produced.
+      tbl_outs: A list of tuples ([opts], out), where each 'opts' is a list of
+        options passed to tblgen, each option being a string, and 'out' is the
+        corresponding output file produced.
       td_srcs: See gentbl_rule.td_srcs
       includes: See gentbl_rule.includes
       td_includes: See gentbl_rule.td_includes
@@ -324,67 +412,69 @@ def gentbl(
       test: whether to create a shell test that invokes the tool too.
       **kwargs: Extra keyword arguments to pass to all generated rules.
     """
-    llvm_project_execroot_path = Label("//mlir:tblgen.bzl", relative_to_caller_repository = False).workspace_root
 
+    filegroup_name = name + "_filegroup"
+    gentbl_filegroup(
+        name = filegroup_name,
+        tblgen = tblgen,
+        td_file = td_file,
+        tbl_outs = tbl_outs,
+        td_srcs = td_srcs,
+        td_includes = td_includes,
+        includes = includes + td_relative_includes,
+        deps = deps,
+        test = test,
+        skip_opts = ["-gen-op-doc"],
+        **kwargs
+    )
+    native.cc_library(
+        name = name,
+        # strip_include_prefix does not apply to textual_hdrs.
+        # https://github.com/bazelbuild/bazel/issues/12424
+        hdrs = [":" + filegroup_name] if strip_include_prefix else [],
+        strip_include_prefix = strip_include_prefix,
+        textual_hdrs = [":" + filegroup_name],
+        **kwargs
+    )
+
+def gentbl(
+        name,
+        tblgen,
+        td_file,
+        tbl_outs,
+        td_srcs = [],
+        td_includes = [],
+        includes = [],
+        td_relative_includes = [],
+        deps = [],
+        test = False,
+        **kwargs):
+    """Deprecated version of gentbl_cc_library.
+
+    Accepts tbl_outs as list of pairs with the first element of the pair being
+    a whitespace-separated string of options rather than a list of options.
+    """
+
+    split_opts = []
     for (opts_string, out) in tbl_outs:
-        # TODO(gcmn): The API of opts as single string is preserved for backward
-        # compatibility. Change to taking a sequence.
         opts = opts_string.split(" ") if opts_string else []
 
         # Filter out empty options
         opts = [opt for opt in opts if opt]
 
-        first_opt = opts[0] if opts else ""
-        rule_suffix = "_{}_{}".format(
-            first_opt.replace("-", "_").replace("=", "_"),
-            str(hash(opts_string)),
-        )
-        gentbl_name = "%s_%s_genrule" % (name, rule_suffix)
-        gentbl_rule(
-            name = gentbl_name,
-            td_file = td_file,
-            tblgen = tblgen,
-            opts = opts,
-            td_srcs = td_srcs,
-            deps = deps,
-            includes = includes + td_relative_includes,
-            # TODO(gcmn): Update callers to td_library and explicit includes and
-            # drop this hardcoded include.
-            td_includes = td_includes + [
-                "%s/mlir/include" % llvm_project_execroot_path,
-            ],
-            out = out,
-            **kwargs
-        )
-        if test:
-            # Also run the generator in the target configuration as a test. This
-            # means it gets run with asserts and sanitizers and such when they
-            # are enabled and is counted in coverage.
-            gentbl_test(
-                name = "%s_test" % (gentbl_name,),
-                td_file = td_file,
-                tblgen = tblgen,
-                opts = opts,
-                td_srcs = td_srcs,
-                deps = deps,
-                includes = includes + td_relative_includes,
-                # TODO(gcmn): Update callers to td_library and explicit includes
-                # and drop this hardcoded include.
-                td_includes = td_includes + [
-                    "%s/mlir/include" % llvm_project_execroot_path,
-                ],
-                **kwargs
-            )
+        split_opts.append((opts, out))
 
-    # List of opts that do not generate cc files.
-    skip_opts = ["-gen-op-doc"]
-    hdrs = [f for (opts, f) in tbl_outs if opts not in skip_opts]
-    native.cc_library(
+    gentbl_cc_library(
         name = name,
-        # strip_include_prefix does not apply to textual_hdrs.
-        # https://github.com/bazelbuild/bazel/issues/12424
-        hdrs = hdrs if strip_include_prefix else [],
-        strip_include_prefix = strip_include_prefix,
-        textual_hdrs = hdrs,
+        tblgen = tblgen,
+        td_file = td_file,
+        tbl_outs = split_opts,
+        td_srcs = td_srcs,
+        td_includes = td_includes,
+        includes = includes,
+        td_relative_includes = td_relative_includes,
+        deps = deps,
+        test = test,
+        deprecation = "generated by gentbl; use gentbl_cc_library or gentbl_filegroup instead",
         **kwargs
     )

--- a/llvm-bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/llvm-bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//mlir:tblgen.bzl", "gentbl", "td_library")
+load("//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -50,40 +50,43 @@ td_library(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TestOpsIncGen",
     strip_include_prefix = "lib/Dialect/Test",
     tbl_outs = [
         (
-            "-gen-op-decls",
+            ["-gen-op-decls"],
             "lib/Dialect/Test/TestOps.h.inc",
         ),
         (
-            "-gen-op-defs",
+            ["-gen-op-defs"],
             "lib/Dialect/Test/TestOps.cpp.inc",
         ),
         (
-            "-gen-dialect-decls -dialect=test",
+            [
+                "-gen-dialect-decls",
+                "-dialect=test",
+            ],
             "lib/Dialect/Test/TestOpsDialect.h.inc",
         ),
         (
-            "-gen-enum-decls",
+            ["-gen-enum-decls"],
             "lib/Dialect/Test/TestOpEnums.h.inc",
         ),
         (
-            "-gen-enum-defs",
+            ["-gen-enum-defs"],
             "lib/Dialect/Test/TestOpEnums.cpp.inc",
         ),
         (
-            "-gen-struct-attr-decls",
+            ["-gen-struct-attr-decls"],
             "lib/Dialect/Test/TestOpStructs.h.inc",
         ),
         (
-            "-gen-struct-attr-defs",
+            ["-gen-struct-attr-defs"],
             "lib/Dialect/Test/TestOpStructs.cpp.inc",
         ),
         (
-            "-gen-rewriters",
+            ["-gen-rewriters"],
             "lib/Dialect/Test/TestPatterns.inc",
         ),
     ],
@@ -95,24 +98,24 @@ gentbl(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TestInterfacesIncGen",
     strip_include_prefix = "lib/Dialect/Test",
     tbl_outs = [
         (
-            "-gen-type-interface-decls",
+            ["-gen-type-interface-decls"],
             "lib/Dialect/Test/TestTypeInterfaces.h.inc",
         ),
         (
-            "-gen-type-interface-defs",
+            ["-gen-type-interface-defs"],
             "lib/Dialect/Test/TestTypeInterfaces.cpp.inc",
         ),
         (
-            "-gen-op-interface-decls",
+            ["-gen-op-interface-decls"],
             "lib/Dialect/Test/TestOpInterfaces.h.inc",
         ),
         (
-            "-gen-op-interface-defs",
+            ["-gen-op-interface-defs"],
             "lib/Dialect/Test/TestOpInterfaces.cpp.inc",
         ),
     ],
@@ -125,16 +128,16 @@ gentbl(
     ],
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TestAttrDefsIncGen",
     strip_include_prefix = "lib/Dialect/Test",
     tbl_outs = [
         (
-            "-gen-attrdef-decls",
+            ["-gen-attrdef-decls"],
             "lib/Dialect/Test/TestAttrDefs.h.inc",
         ),
         (
-            "-gen-attrdef-defs",
+            ["-gen-attrdef-defs"],
             "lib/Dialect/Test/TestAttrDefs.cpp.inc",
         ),
     ],
@@ -146,16 +149,16 @@ gentbl(
     test = True,
 )
 
-gentbl(
+gentbl_cc_library(
     name = "TestTypeDefsIncGen",
     strip_include_prefix = "lib/Dialect/Test",
     tbl_outs = [
         (
-            "-gen-typedef-decls",
+            ["-gen-typedef-decls"],
             "lib/Dialect/Test/TestTypeDefs.h.inc",
         ),
         (
-            "-gen-typedef-defs",
+            ["-gen-typedef-defs"],
             "lib/Dialect/Test/TestTypeDefs.cpp.inc",
         ),
     ],


### PR DESCRIPTION
Add `gentbl_filegroup`. Rename `gentbl` to `gentbl_cc_library` to make it clearer which
kind of rule is ultimately used.

Update `gentbl_*` macros to take `tbl_outs` options as a list rather a
whitespace-separated string and remove the related string handling.
