### PR TITLE
Integrate LLVM at llvm/llvm-project@6359842bc088

### DIFF
--- a/llvm-bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/llvm-bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -183,7 +183,7 @@ cc_library(
     hdrs = glob([
         "include/llvm/Support/**/*.h",
         "include/llvm/ADT/*.h",
-        "include/llvm/MC/*.h",  # TODO(b/189134997)
+        "include/llvm/MC/*.h",  # TODO(maskray): Fix the layering issue.
     ]) + [
         "include/llvm-c/Core.h",
         "include/llvm-c/DataTypes.h",
@@ -923,7 +923,6 @@ cc_library(
         "lib/Transforms/Utils/*.h",
     ]),
     hdrs = glob(["include/llvm/Transforms/Utils/*.h"]) + [
-        "include/llvm/Transforms/Scalar/LoopPassManager.h",
         "include/llvm/Transforms/Utils.h",
         "include/llvm-c/Transforms/Utils.h",
     ],


### PR DESCRIPTION
Update BUILD files and submodule for
[6359842bc088](https://github.com/llvm/llvm-project/commit/6359842bc088)

No change actually *needed* for this, but allows removing a set of
headers from support that are no longer necessary. While I was here,
fixed a TODO pointing at an internal bug number.