### PR TITLE
Integrate LLVM at llvm/llvm-project@36111f28edb1

### DIFF
--- a/llvm-bazel/llvm-project-overlay/.bazelignore
+++ b/llvm-bazel/llvm-project-overlay/.bazelignore
@@ -1,0 +1,2 @@
+# Ignore the utils/bazel directory when this is overlayed onto the repo root.
+utils/bazel


### PR DESCRIPTION
Update BUILD files and submodule for
[36111f28edb1](https://github.com/llvm/llvm-project/commit/36111f28edb1)

Pulls in the .bazelignore to ignore the now upstreamed Bazel build
files.