### PR TITLE
Change external_zlib attribute to string

### DIFF
--- a/llvm-bazel/zlib.bzl
+++ b/llvm-bazel/zlib.bzl
@@ -24,7 +24,7 @@ def _llvm_zlib_external_impl(repository_ctx):
         "BUILD",
         repository_ctx.attr._external_build_template,
         substitutions = {
-            "@external_zlib_repo//:zlib_rule": str(repository_ctx.attr.external_zlib),
+            "@external_zlib_repo//:zlib_rule": repository_ctx.attr.external_zlib,
         },
         executable = False,
     )
@@ -36,7 +36,7 @@ llvm_zlib_external = repository_rule(
             default = Label("//deps_impl:zlib_external.BUILD"),
             allow_single_file = True,
         ),
-        "external_zlib": attr.label(
+        "external_zlib": attr.string(
             doc = "The dependency that should be used for the external zlib library.",
             mandatory = True,
         ),


### PR DESCRIPTION
When using `llvm_zlib_external` rule with `external_zlib` attribute set to a label referring to the main repository, like `@//third_party/zlib`, it will be replaced with `//third_party/zlib` after template substitution. This will then attempt to find `//third_party/zlib` within the local repository `@llvm_zlib//third_party/zlib`, which does not exist, rather than the intended reference back to the main repository. The issue appears to be that the conversion of `Label` type to string with `str(repository_ctx.attr.external_zlib)`, which is causing the main repository qualifier to be lost.

This PR fixes the issue by changing the `external_zlib` attribute to `attr.string` type rather than `attr.label`.